### PR TITLE
[POC] [Snippets] [CPU] Snippets for ARM

### DIFF
--- a/src/common/snippets/src/pass/collapse_subgraph.cpp
+++ b/src/common/snippets/src/pass/collapse_subgraph.cpp
@@ -46,6 +46,7 @@ auto outputs_are_not_broadcastable(const std::shared_ptr<const Node>& node) -> b
 auto is_supported_op(const std::shared_ptr<const Node> &n) -> bool {
     OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "Snippets::is_supported_op")
     auto is_supported_matmul = [](const std::shared_ptr<const Node>& n) -> bool {
+#if defined(OPENVINO_ARCH_X86_64)
         const auto& matmul = ov::as_type_ptr<const opset1::MatMul>(n);
         const auto& out_shape = n->get_output_partial_shape(0);
         if (!matmul || out_shape.is_dynamic() || out_shape.size() != 4)
@@ -56,8 +57,13 @@ auto is_supported_op(const std::shared_ptr<const Node> &n) -> bool {
         const bool is_int8 = (intype_0 == element::i8 || intype_0 == element::u8) && (intype_1 == element::i8);
         const bool is_bf16 = intype_0 == element::bf16 && intype_1 == element::bf16;
         return is_f32 || is_bf16 || is_int8;
+#elif defined(OPENVINO_ARCH_ARM64)
+        return false;
+#endif
+        return false;
     };
     auto is_supported_transpose = [](const std::shared_ptr<const Node>& n) -> bool {
+#if defined(OPENVINO_ARCH_X86_64)
         const auto& transpose = as_type_ptr<const opset1::Transpose>(n);
         const auto& out_shape = n->get_output_partial_shape(0);
         if (transpose && out_shape.is_static()) {
@@ -81,17 +87,32 @@ auto is_supported_op(const std::shared_ptr<const Node> &n) -> bool {
             }
         }
         return false;
+#elif defined(OPENVINO_ARCH_ARM64)
+        return false;
+#endif
+        return false;
     };
 
     auto is_supported_fq_op = [](const std::shared_ptr<const Node>& n) -> bool {
+#if defined(OPENVINO_ARCH_X86_64)
         return CommonFakeQuantizeDecomposition::is_supported_fq(ov::as_type_ptr<const opset1::FakeQuantize>(n));
+#elif defined(OPENVINO_ARCH_ARM64)
+        return false;
+#endif
+        return false;
     };
 
     auto is_supported_ternary_eltwise_op = [](const std::shared_ptr<const Node> &n) -> bool {
+#if defined(OPENVINO_ARCH_X86_64)
         return ov::is_type<ov::op::v1::Select>(n);
+#elif defined(OPENVINO_ARCH_ARM64)
+        return false;
+#endif
+        return false;
     };
 
     auto is_supported_binary_eltwise_op = [](const std::shared_ptr<const Node> &n) -> bool {
+#if defined(OPENVINO_ARCH_X86_64)
         return ov::is_type<ov::op::v1::Add>(n)
             || ov::is_type<ov::op::v1::Divide>(n)
             || ov::is_type<ov::op::v1::Equal>(n)
@@ -114,9 +135,15 @@ auto is_supported_op(const std::shared_ptr<const Node> &n) -> bool {
             || ov::is_type<ov::op::v1::Subtract>(n)
             || ov::is_type<ov::op::v0::Xor>(n)
             || ov::is_type<ov::op::v0::Convert>(n);
+#elif defined(OPENVINO_ARCH_ARM64)
+        return ov::is_type<ov::op::v1::Add>(n)
+            || ov::is_type<ov::op::v1::Multiply>(n);
+#endif
+        return false;
     };
 
     auto is_supported_unary_eltwise_op = [](const std::shared_ptr<const Node> &n) -> bool {
+#if defined(OPENVINO_ARCH_X86_64)
         return ov::is_type<ov::op::v0::Abs>(n)
             || ov::is_type<ov::op::v0::Clamp>(n)
             || ov::is_type<ov::op::v0::Floor>(n)
@@ -135,9 +162,14 @@ auto is_supported_op(const std::shared_ptr<const Node> &n) -> bool {
             || ov::is_type<ov::op::v7::Gelu>(n)
             || ov::is_type<ov::op::v4::Swish>(n)
             || ov::is_type<ov::op::v4::HSwish>(n);
+#elif defined(OPENVINO_ARCH_ARM64)
+        return ov::is_type<ov::op::v0::Relu>(n);
+#endif
+        return false;
     };
 
     auto is_supported_softmax = [](const std::shared_ptr<const Node> &n) -> bool {
+#if defined(OPENVINO_ARCH_X86_64)
         if (n->get_input_size() != 1 || n->get_input_partial_shape(0).rank().is_dynamic())
             return false;
         int64_t axis = -1;
@@ -150,15 +182,24 @@ auto is_supported_op(const std::shared_ptr<const Node> &n) -> bool {
             return false;
         }
         return axis >= 0 && axis == (rank.get_length() - 1);
+#elif defined(OPENVINO_ARCH_ARM64)
+        return false;
+#endif
+        return false;
     };
 
     auto is_supported_broadcast_op = [](const std::shared_ptr<const Node> &n) -> bool {
+#if defined(OPENVINO_ARCH_X86_64)
         // Broadcast is supported only for MHA tokenization where there are needed and special checks
         if (auto broadcast_v1 = ov::as_type_ptr<const ov::op::v1::Broadcast>(n)) {
             return broadcast_v1->get_broadcast_spec().m_type == ov::op::AutoBroadcastType::NUMPY;
         } else if (auto broadcast_v3 = ov::as_type_ptr<const ov::op::v3::Broadcast>(n)) {
             return broadcast_v3->get_broadcast_spec().m_type == ov::op::BroadcastType::NUMPY;
         }
+        return false;
+#elif defined(OPENVINO_ARCH_ARM64)
+        return false;
+#endif
         return false;
     };
 

--- a/src/plugins/intel_cpu/CMakeLists.txt
+++ b/src/plugins/intel_cpu/CMakeLists.txt
@@ -95,14 +95,17 @@ endif()
 if(NOT X86_64)
     list(APPEND EXCLUDE_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/src/nodes/executors/x64/*
                               ${CMAKE_CURRENT_SOURCE_DIR}/src/nodes/kernels/x64/*
-                              ${CMAKE_CURRENT_SOURCE_DIR}/src/emitters/x64/*
+                              ${CMAKE_CURRENT_SOURCE_DIR}/src/emitters/plugin/x64/*
+                              ${CMAKE_CURRENT_SOURCE_DIR}/src/emitters/snippets/x64/*
                               ${CMAKE_CURRENT_SOURCE_DIR}/src/transformations/cpu_opset/x64/*
                               ${CMAKE_CURRENT_SOURCE_DIR}/src/transformations/snippets/x64/*)
 endif()
 
 if(NOT (AARCH64 OR ARM))
     list(APPEND EXCLUDE_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/src/transformations/cpu_opset/arm/*
+                              ${CMAKE_CURRENT_SOURCE_DIR}/src/transformations/snippets/aarch64/*
                               ${CMAKE_CURRENT_SOURCE_DIR}/src/emitters/plugin/aarch64/*
+                              ${CMAKE_CURRENT_SOURCE_DIR}/src/emitters/snippets/aarch64/*
                               ${CMAKE_CURRENT_SOURCE_DIR}/src/nodes/executors/aarch64/*
                               ${CMAKE_CURRENT_SOURCE_DIR}/src/nodes/kernels/aarch64/*)
 endif()

--- a/src/plugins/intel_cpu/src/emitters/plugin/aarch64/jit_emitter.cpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/aarch64/jit_emitter.cpp
@@ -71,6 +71,10 @@ size_t jit_emitter::get_aux_vecs_count() const {
     return 0;
 }
 
+emitter_in_out_map jit_emitter::get_in_out_type() const {
+    return in_out_type_;
+}
+
 void jit_emitter::prepare_table() {
     register_table_entries();
 
@@ -90,6 +94,8 @@ void jit_emitter::emitter_preamble(const std::vector<size_t>& in_idxs,
                                    const std::vector<size_t>& out_idxs,
                                    const std::vector<size_t>& pool_aux_vec_idxs,
                                    const std::vector<size_t>& pool_aux_gpr_idxs) const {
+    // todo: like on x64, push back preserved_vec_idxs/preserved_gpr_idxs and preserve correspoding registers,
+    // if and only if the caller provided aux_vec_idxs/aux_gpr_idxs are not enough.
     if (pool_aux_vec_idxs.size() < get_aux_vecs_count()) {
         OPENVINO_THROW("Failed to allocate required number of vector registers");
     }
@@ -104,7 +110,6 @@ void jit_emitter::emitter_preamble(const std::vector<size_t>& in_idxs,
 
     for (auto idx : pool_aux_gpr_idxs) {
         aux_gpr_idxs.push_back(static_cast<uint32_t>(idx));
-        preserved_gpr_idxs.push_back(static_cast<uint32_t>(idx));
     }
 
     if (!entry_map_.empty()) {
@@ -113,22 +118,12 @@ void jit_emitter::emitter_preamble(const std::vector<size_t>& in_idxs,
         aux_gpr_idxs.erase(aux_gpr_idxs.end() - 1);
     }
 
-    for (size_t i = 0; i < preserved_gpr_idxs.size(); ++i) {
-        h->str(Xbyak_aarch64::XReg(preserved_gpr_idxs[i]), pre_ptr(h->sp, -16));
-    }
-
     if (!entry_map_.empty()) {
         load_table_addr();
     }
 }
 
 void jit_emitter::emitter_postamble() const {
-    const int size = static_cast<int>(preserved_gpr_idxs.size());
-    for (int i = (size - 1); i >= 0; --i) {
-        h->ldr(Xbyak_aarch64::XReg(preserved_gpr_idxs[i]), post_ptr(h->sp, 16));
-    }
-    preserved_gpr_idxs.clear();
-
     aux_vec_idxs.clear();
     aux_gpr_idxs.clear();
 }

--- a/src/plugins/intel_cpu/src/emitters/plugin/aarch64/jit_emitter.hpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/aarch64/jit_emitter.hpp
@@ -61,6 +61,7 @@ public:
     virtual size_t get_inputs_count() const = 0;
     virtual size_t get_aux_vecs_count() const;
     virtual size_t get_aux_gprs_count() const;
+    emitter_in_out_map get_in_out_type() const;
 
     /**
      * @brief Returns supported precisions.
@@ -173,6 +174,8 @@ private:
         const auto scale = te.bcast ? get_vec_length() : sizeof(table_entry_val_t);
         return te.off + key_off_val_shift * scale;
     }
+
+    virtual void validate_arguments(const std::vector<size_t>&, const std::vector<size_t>&) const {}
 
     static inline size_t get_asimd_vectors_count() {
         return 32;

--- a/src/plugins/intel_cpu/src/emitters/plugin/aarch64/jit_load_store_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/aarch64/jit_load_store_emitters.cpp
@@ -1,0 +1,141 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "jit_load_store_emitters.hpp"
+#include "cpu/aarch64/cpu_isa_traits.hpp"
+
+using namespace Xbyak_aarch64;
+
+namespace ov {
+namespace intel_cpu {
+namespace aarch64 {
+
+using jit_generator = dnnl::impl::cpu::aarch64::jit_generator;
+using cpu_isa_t = dnnl::impl::cpu::aarch64::cpu_isa_t;
+
+jit_load_emitter::jit_load_emitter(dnnl::impl::cpu::aarch64::jit_generator *host, dnnl::impl::cpu::aarch64::cpu_isa_t host_isa,
+                                   ov::element::Type src_prc, ov::element::Type dst_prc, int load_num, int byte_offset,
+                                   ov::element::Type exec_prc, bool is_fill, std::string fill_value, emitter_in_out_map in_out_type)
+: jit_emitter(host, host_isa, exec_prc, in_out_type), name_("unknown"), load_num_(load_num), byte_offset_(byte_offset),
+              src_prc_(src_prc), dst_prc_(dst_prc), is_fill_(is_fill), fill_value_(fill_value) {
+    prepare_table();
+    load_size_ = load_num * src_prc.size();
+    v_len_elt_ = get_vec_length() / exec_prc.size();
+}
+
+void jit_load_emitter::emit_impl(const std::vector<size_t> &in_idxs, const std::vector<size_t> &out_idxs) const {
+    if (host_isa_ == dnnl::impl::cpu::aarch64::asimd) {
+        emit_isa<dnnl::impl::cpu::aarch64::asimd>(in_idxs, out_idxs);
+    } else {
+        OPENVINO_THROW("Load emitter in ", name_, " is performed on unsupported isa.");
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_load_emitter::emit_isa(const std::vector<size_t> &in_idxs, const std::vector<size_t> &out_idxs) const {
+    bool matched_prc = src_prc_ == ov::element::f32 && dst_prc_ == ov::element::f32;
+    if (!matched_prc)
+        OPENVINO_THROW("Load emitter in ", name_, " only support both input and output precisions of being FP32.");
+    if (load_num_ > static_cast<int>((get_vec_length() / dst_prc_.size())))
+        OPENVINO_THROW("Load emitter in ", name_, " have unexpected number of elements to load.");
+
+    using TReg = typename dnnl::impl::cpu::aarch64::cpu_isa_traits<isa>::TReg;
+    XReg src = XReg(in_idxs[0]);
+    XReg prc = XReg(aux_gpr_idxs[0]);
+    TReg dst = TReg(out_idxs[0]);
+    SReg dst_s = SReg(out_idxs[0]);
+    DReg dst_d = DReg(out_idxs[0]);
+
+    h->add(prc, src, byte_offset_);
+
+    switch (load_num_) {
+        case 0:
+            break;
+        case 1:
+            h->ldr(dst_s, ptr(prc));
+            break;
+        case 2:
+            h->ldr(dst_d, ptr(prc));
+            break;
+        case 3:
+            h->ldr(dst_d, ptr(prc));
+            h->add(prc, prc, 2 * sizeof(float));
+            h->ld1(dst.s[2], ptr(prc));
+            break;
+        case 4:
+            h->uni_ldr(dst, prc);
+            break;
+        default:
+            OPENVINO_THROW("Load emitter in ", name_, " has unexpected number of elements to load.");
+    }
+}
+
+size_t jit_load_emitter::get_aux_gprs_count() const {
+    return 1;
+}
+
+jit_store_emitter::jit_store_emitter(dnnl::impl::cpu::aarch64::jit_generator *host, dnnl::impl::cpu::aarch64::cpu_isa_t host_isa,
+                                     ov::element::Type src_prc, ov::element::Type dst_prc, int store_num, int byte_offset,
+                                     arithmetic_mode mode, ov::element::Type exec_prc, emitter_in_out_map in_out_type)
+    : jit_emitter(host, host_isa, exec_prc, in_out_type), name_("unknown"), store_num_(store_num), byte_offset_(byte_offset),
+                  src_prc_(src_prc), dst_prc_(dst_prc), mode_(mode) {
+    prepare_table();
+    v_len_elt_ = get_vec_length() / exec_prc.size();
+    store_size_ = store_num * dst_prc.size();
+}
+
+void jit_store_emitter::emit_impl(const std::vector<size_t> &in_idxs, const std::vector<size_t> &out_idxs) const {
+    if (host_isa_ == dnnl::impl::cpu::aarch64::asimd) {
+        emit_isa<dnnl::impl::cpu::aarch64::asimd>(in_idxs, out_idxs);
+    } else {
+        OPENVINO_THROW("Store emitter in ", name_, " is performed on unsupported isa.");
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_store_emitter::emit_isa(const std::vector<size_t> &in_idxs, const std::vector<size_t> &out_idxs) const {
+    bool matched_prc = src_prc_ == ov::element::f32 && dst_prc_ == ov::element::f32;
+    if (!matched_prc)
+        OPENVINO_THROW("Store emitter in ", name_, " only support both input and output precisions of being FP32.");
+    if (store_num_ > static_cast<int>((get_vec_length() / dst_prc_.size())))
+        OPENVINO_THROW("Store emitter in ", name_, " have unexpected number of elements to store.");
+
+    using TReg = typename dnnl::impl::cpu::aarch64::cpu_isa_traits<isa>::TReg;
+    TReg src = TReg(in_idxs[0]);
+    SReg src_s = SReg(in_idxs[0]);
+    DReg src_d = DReg(in_idxs[0]);
+    XReg dst = XReg(out_idxs[0]);
+    XReg prc = XReg(aux_gpr_idxs[0]);
+
+    h->add(prc, dst, byte_offset_);
+
+    switch (store_num_) {
+        case 0:
+            break;
+        case 1:
+            h->str(src_s, ptr(prc));
+            break;
+        case 2:
+            h->str(src_d, ptr(prc));
+            break;
+        case 3:
+            h->str(src_d, ptr(prc));
+            h->add(prc, prc, 2 * sizeof(float));
+            h->st1(src.s[2], ptr(prc));
+            break;
+        case 4:
+            h->str(QReg(src.getIdx()), ptr(prc));
+            break;
+        default:
+            OPENVINO_THROW("Store emitter in ", name_, " has unexpected number of elements to store.");
+    }
+}
+
+size_t jit_store_emitter::get_aux_gprs_count() const {
+    return 1;
+}
+
+}   // namespace aarch64
+}   // namespace intel_cpu
+}   // namespace ov

--- a/src/plugins/intel_cpu/src/emitters/plugin/aarch64/jit_load_store_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/aarch64/jit_load_store_emitters.hpp
@@ -1,0 +1,75 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "jit_emitter.hpp"
+#include "cpu/aarch64/jit_generator.hpp"
+
+namespace ov {
+namespace intel_cpu {
+namespace aarch64 {
+
+// Arithmetic modes for data type conversion in store_emitter
+enum arithmetic_mode {
+    saturation,
+    truncation
+};
+
+class jit_load_emitter : public jit_emitter {
+public:
+    jit_load_emitter(dnnl::impl::cpu::aarch64::jit_generator *host, dnnl::impl::cpu::aarch64::cpu_isa_t host_isa,
+                     ov::element::Type src_prc, ov::element::Type dst_prc, int load_num, int byte_offset,
+                     ov::element::Type exec_prc = ov::element::f32,
+                     bool is_fill = false, std::string fill_value = "zero",
+                     emitter_in_out_map in_out_type = emitter_in_out_map::gpr_to_vec);
+
+    void emit_impl(const std::vector<size_t> &in_idxs, const std::vector<size_t> &out_idxs) const override;
+    size_t get_inputs_count() const override { return 1; };
+
+private:
+    template <dnnl::impl::cpu::aarch64::cpu_isa_t isa>
+    void emit_isa(const std::vector<size_t> &in_idxs, const std::vector<size_t> &out_idxs) const;
+    size_t get_aux_gprs_count() const override;
+
+    std::string name_;
+    int v_len_elt_; // the element number that a vector register can hold maximumly
+    int load_num_;  // the element number to load
+    int load_size_; // the byte number to load
+    int byte_offset_;
+    ov::element::Type src_prc_;
+    ov::element::Type dst_prc_;
+    bool is_fill_;
+    std::string fill_value_;
+};
+
+class jit_store_emitter : public jit_emitter {
+public:
+    jit_store_emitter(dnnl::impl::cpu::aarch64::jit_generator *host, dnnl::impl::cpu::aarch64::cpu_isa_t host_isa,
+                      ov::element::Type src_prc, ov::element::Type dst_prc, int store_num, int byte_offset_,
+                      arithmetic_mode mode = arithmetic_mode::saturation,
+                      ov::element::Type exec_prc = ov::element::f32,
+                      emitter_in_out_map in_out_type = emitter_in_out_map::vec_to_gpr);
+
+    void emit_impl(const std::vector<size_t> &in_idxs, const std::vector<size_t> &out_idxs) const override;
+    size_t get_inputs_count() const override { return 1; }
+
+private:
+    template <dnnl::impl::cpu::aarch64::cpu_isa_t isa>
+    void emit_isa(const std::vector<size_t> &in_idxs, const std::vector<size_t> &out_idxs) const;
+    size_t get_aux_gprs_count() const override;
+
+    std::string name_;
+    int v_len_elt_;  // the element number that a vector register can hold maximumly
+    int store_num_;  // the element number to store
+    int store_size_; // the byte number to store
+    int byte_offset_;
+    ov::element::Type src_prc_;
+    ov::element::Type dst_prc_;
+    arithmetic_mode mode_ = arithmetic_mode::saturation;
+};
+
+}   // namespace aarch64
+}   // namespace intel_cpu
+}   // namespace ov

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/cpu_generator.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/cpu_generator.cpp
@@ -1,0 +1,144 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "snippets/snippets_isa.hpp"
+#include "cpu_generator.hpp"
+#include "jit_snippets_emitters.hpp"
+#include "emitters/plugin/aarch64/jit_eltwise_emitters.hpp"
+#include "emitters/snippets/aarch64/jit_kernel_emitter.hpp"
+#include "emitters/snippets/aarch64/jit_loop_emitters.hpp"
+#include "emitters/snippets/aarch64/jit_memory_emitters.hpp"
+#include "emitters/snippets/aarch64/jit_fill_emitter.hpp"
+
+#include "openvino/opsets/opset13.hpp"
+
+namespace ov {
+
+#define CREATE_SNIPPETS_EMITTER(e_type) { \
+    [this](const snippets::lowered::ExpressionPtr& expr) -> std::shared_ptr<snippets::Emitter> { \
+        return std::make_shared<e_type>(h.get(), isa, expr); \
+    }, \
+    [](const std::shared_ptr<ov::Node>& n) -> std::set<std::vector<element::Type>> { \
+        return e_type::get_supported_precisions(n); \
+    } \
+}
+
+#define CREATE_CPU_EMITTER(e_type) { \
+    [this](const snippets::lowered::ExpressionPtr& expr) -> std::shared_ptr<snippets::Emitter> { \
+        return std::make_shared<e_type>(h.get(), isa, expr->get_node()); \
+    }, \
+    [](const std::shared_ptr<ov::Node>& n) -> std::set<std::vector<element::Type>> { \
+        return e_type::get_supported_precisions(n); \
+    } \
+}
+
+class jit_snippet : public dnnl::impl::cpu::aarch64::jit_generator {
+public:
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_snippet)
+
+    ~jit_snippet() = default;
+
+    jit_snippet() : jit_generator() {}
+
+    void generate() override {}
+};
+
+namespace intel_cpu {
+namespace aarch64 {
+
+CompiledSnippetCPU::CompiledSnippetCPU(std::unique_ptr<dnnl::impl::cpu::aarch64::jit_generator> h) : h_compiled(std::move(h)) {
+    OPENVINO_ASSERT(h_compiled && h_compiled->jit_ker(), "Got invalid jit generator or kernel was nopt compiled");
+}
+
+const uint8_t* CompiledSnippetCPU::get_code() const {
+    return h_compiled->jit_ker();
+}
+
+size_t CompiledSnippetCPU::get_code_size() const {
+    return h_compiled->getSize();
+}
+
+bool CompiledSnippetCPU::empty() const {
+    return get_code_size() == 0;
+}
+
+CPUTargetMachine::CPUTargetMachine(dnnl::impl::cpu::aarch64::cpu_isa_t host_isa)
+    : TargetMachine(), h(new jit_snippet()), isa(host_isa) {
+    // data movement
+    jitters[op::v0::Parameter::get_type_info_static()] = CREATE_SNIPPETS_EMITTER(NopEmitter);
+    jitters[op::v0::Result::get_type_info_static()] = CREATE_SNIPPETS_EMITTER(NopEmitter);
+    jitters[snippets::op::VectorBuffer::get_type_info_static()] = CREATE_SNIPPETS_EMITTER(NopEmitter);
+    jitters[snippets::op::RankNormalization::get_type_info_static()] = CREATE_SNIPPETS_EMITTER(NopEmitter);
+    jitters[snippets::op::BroadcastMove::get_type_info_static()] = CREATE_SNIPPETS_EMITTER(BroadcastMoveEmitter);
+
+    // memory access
+    jitters[snippets::op::Load::get_type_info_static()] = CREATE_SNIPPETS_EMITTER(jit_load_memory_emitter);
+    jitters[snippets::op::BroadcastLoad::get_type_info_static()] = CREATE_SNIPPETS_EMITTER(jit_load_broadcast_emitter);
+    jitters[snippets::op::Store::get_type_info_static()] = CREATE_SNIPPETS_EMITTER(jit_store_memory_emitter);
+
+    // binary
+    jitters[op::v1::Add::get_type_info_static()] = CREATE_CPU_EMITTER(jit_add_emitter);
+    jitters[op::v1::Multiply::get_type_info_static()] = CREATE_CPU_EMITTER(jit_multiply_emitter);
+
+    // unary
+    jitters[ov::op::v0::Relu::get_type_info_static()] = CREATE_CPU_EMITTER(jit_relu_emitter);
+
+    // control flow
+    jitters[snippets::op::Kernel::get_type_info_static()] = CREATE_SNIPPETS_EMITTER(KernelEmitter);
+    jitters[snippets::op::LoopBegin::get_type_info_static()] = CREATE_SNIPPETS_EMITTER(LoopBeginEmitter);
+    jitters[snippets::op::LoopEnd::get_type_info_static()] = CREATE_SNIPPETS_EMITTER(LoopEndEmitter);
+
+    // others
+    jitters[snippets::op::Scalar::get_type_info_static()] = CREATE_SNIPPETS_EMITTER(ScalarEmitter);
+    jitters[snippets::op::Fill::get_type_info_static()] = CREATE_SNIPPETS_EMITTER(FillEmitter);
+}
+
+bool CPUTargetMachine::is_supported() const {
+    return dnnl::impl::cpu::aarch64::mayiuse(isa);
+}
+
+snippets::CompiledSnippetPtr CPUTargetMachine::get_snippet() {
+    if (h->create_kernel() != dnnl::impl::status::success) {
+        OPENVINO_THROW("Failed to create jit_kernel in get_snippet()");
+    }
+    const auto& result = std::make_shared<CompiledSnippetCPU>(std::unique_ptr<dnnl::impl::cpu::aarch64::jit_generator>(h.release()));
+    // Note that we reset all the generated code, since it was copied into CompiledSnippetCPU
+    h.reset(new jit_snippet());
+    return result;
+}
+
+size_t CPUTargetMachine::get_lanes() const {
+    switch (isa) {
+        case dnnl::impl::cpu::aarch64::asimd : return dnnl::impl::cpu::aarch64::cpu_isa_traits<dnnl::impl::cpu::aarch64::asimd>::vlen / sizeof(float);
+        default : OPENVINO_THROW("unknown isa ", isa);
+    }
+}
+
+dnnl::impl::cpu::aarch64::cpu_isa_t CPUTargetMachine::get_isa() const {
+    return isa;
+}
+
+CPUGenerator::CPUGenerator(dnnl::impl::cpu::aarch64::cpu_isa_t isa_) : Generator(std::make_shared<CPUTargetMachine>(isa_)) {}
+
+std::shared_ptr<snippets::Generator> CPUGenerator::clone() const {
+    const auto& cpu_target_machine = std::dynamic_pointer_cast<CPUTargetMachine>(target);
+    OPENVINO_ASSERT(cpu_target_machine, "Failed to clone CPUGenerator: the instance contains incompatible TargetMachine type");
+    return std::make_shared<CPUGenerator>(cpu_target_machine->get_isa());
+}
+
+ov::snippets::RegType CPUGenerator::get_specific_op_out_reg_type(const ov::Output<ov::Node>& out) const {
+    const auto op = out.get_node_shared_ptr();
+    // todo: add implementation
+    OPENVINO_THROW("Register type of the operation " + std::string(op->get_type_name()) + " isn't determined!");
+    return ov::snippets::RegType::gpr;
+}
+
+bool CPUGenerator::uses_precompiled_kernel(const std::shared_ptr<snippets::Emitter>& e) const {
+    // todo: add implementation
+    return false;
+}
+
+}   // namespace aarch64
+}   // namespace intel_cpu
+}   // namespace ov

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/cpu_generator.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/cpu_generator.hpp
@@ -1,0 +1,53 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "cpu/aarch64/jit_generator.hpp"
+
+#include "snippets/target_machine.hpp"
+#include "snippets/generator.hpp"
+
+namespace ov {
+namespace intel_cpu {
+namespace aarch64 {
+
+class CompiledSnippetCPU : public snippets::CompiledSnippet {
+public:
+    explicit CompiledSnippetCPU(std::unique_ptr<dnnl::impl::cpu::aarch64::jit_generator> h);
+    const uint8_t* get_code() const override;
+    size_t get_code_size() const override;
+    bool empty() const override;
+
+private:
+    const std::unique_ptr<const dnnl::impl::cpu::aarch64::jit_generator> h_compiled;
+};
+
+class CPUTargetMachine : public snippets::TargetMachine {
+public:
+    explicit CPUTargetMachine(dnnl::impl::cpu::aarch64::cpu_isa_t host_isa);
+
+    bool is_supported() const override;
+    snippets::CompiledSnippetPtr get_snippet() override;
+    size_t get_lanes() const override;
+    dnnl::impl::cpu::aarch64::cpu_isa_t get_isa() const;
+
+private:
+    std::unique_ptr<dnnl::impl::cpu::aarch64::jit_generator> h;
+    dnnl::impl::cpu::aarch64::cpu_isa_t isa;
+};
+
+class CPUGenerator : public snippets::Generator {
+public:
+    CPUGenerator(dnnl::impl::cpu::aarch64::cpu_isa_t isa);
+    std::shared_ptr<Generator> clone() const override;
+
+protected:
+    bool uses_precompiled_kernel(const std::shared_ptr<snippets::Emitter>& emitter) const override;
+    ov::snippets::RegType get_specific_op_out_reg_type(const ov::Output<ov::Node>& out) const override;
+};
+
+}   // namespace aarch64
+}   // namespace intel_cpu
+}   // namespace ov

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_container_emitter.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_container_emitter.cpp
@@ -1,0 +1,64 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "jit_container_emitter.hpp"
+#include "emitters/utils.hpp"
+
+using namespace Xbyak_aarch64;
+
+namespace ov {
+namespace intel_cpu {
+namespace aarch64 {
+
+using jit_generator = dnnl::impl::cpu::aarch64::jit_generator;
+using cpu_isa_t = dnnl::impl::cpu::aarch64::cpu_isa_t;
+using ExpressionPtr = ov::snippets::lowered::ExpressionPtr;
+
+jit_container_emitter::jit_container_emitter(jit_generator* h, cpu_isa_t isa, const ExpressionPtr& expr)
+    : jit_emitter(h, isa) {
+    in_out_type_ = emitter_in_out_map::gpr_to_gpr;
+}
+
+void jit_container_emitter::map_abstract_registers(mapping_info& gpr_map_pool, mapping_info& vec_map_pool,
+                                                   snippets::lowered::LinearIR::container& expressions) const {
+    OV_CPU_JIT_EMITTER_ASSERT(!expressions.empty(), "Cannot map registers when there is no allocated_emitters provided");
+
+    auto map_regs = [&](const std::vector<snippets::Reg>& abstract_regs) {
+        std::vector<snippets::Reg> physical_regs = abstract_regs;
+        for (size_t i = 0; i < abstract_regs.size(); ++i) {
+            const auto& abstract_reg = abstract_regs[i];
+            const auto& type = abstract_reg.type;
+            const auto& abstract = abstract_reg.idx;
+            OV_CPU_JIT_EMITTER_ASSERT(one_of(type, snippets::RegType::gpr, snippets::RegType::vec), "Incorrect reg type detected!");
+            auto& mapping = type == snippets::RegType::gpr ? gpr_map_pool : vec_map_pool;
+            auto& abstract_to_physical = mapping.first;
+            auto& regs_pool = mapping.second;
+            auto& physical = physical_regs[i];
+            if (abstract_to_physical.count(abstract) == 0) {
+                OV_CPU_JIT_EMITTER_ASSERT(!regs_pool.empty(), "Cannot map registers for jit_container_emitter: not enough regs in the pool");
+                physical.idx = regs_pool.back();
+                regs_pool.pop_back();
+                abstract_to_physical[abstract] = physical.idx;
+            } else {
+                physical.idx = abstract_to_physical[abstract];
+            }
+        }
+        return physical_regs;
+    };
+
+    for (const auto& expression : expressions) {
+        std::vector<snippets::Reg> in_physical_regs, out_physical_regs;
+        std::vector<snippets::Reg> in_abstract_regs, out_abstract_regs;
+        std::tie(in_abstract_regs, out_abstract_regs) = expression->get_reg_info();
+        in_physical_regs = map_regs(in_abstract_regs);
+        out_physical_regs = map_regs(out_abstract_regs);
+        expression->set_reg_info({in_physical_regs, out_physical_regs});
+        if (auto container = std::dynamic_pointer_cast<jit_container_emitter>(expression->get_emitter()))
+            container->map_abstract_registers(gpr_map_pool, vec_map_pool, expressions);
+    }
+}
+
+}   // namespace aarch64
+}   // namespace intel_cpu
+}   // namespace ov

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_container_emitter.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_container_emitter.hpp
@@ -1,0 +1,34 @@
+
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "emitters/plugin/aarch64/jit_emitter.hpp"
+#include "snippets/lowered/linear_ir.hpp"
+
+namespace ov {
+namespace intel_cpu {
+namespace aarch64 {
+
+/// \brief jit_container_emitter designed to wrap Emitters that contain other Emitters (for example, KernelEmitter).
+///  This is needed to provide common interface for register mapping
+/// (abstract to physical) and nested code access.
+class jit_container_emitter: public jit_emitter {
+public:
+    jit_container_emitter(dnnl::impl::cpu::aarch64::jit_generator* h,
+                          dnnl::impl::cpu::aarch64::cpu_isa_t isa,
+                          const ov::snippets::lowered::ExpressionPtr& expr);
+    // mapping info contains abstract_to_physical map + regs_pool
+    using mapping_info = std::pair<std::map<size_t, size_t>, std::vector<size_t>&>;
+protected:
+    // maps gpr and vec abstract registers to physical ones.
+    void map_abstract_registers(mapping_info& gpr_map_pool,  mapping_info& vec_map_pool,
+                                snippets::lowered::LinearIR::container& expressions) const;
+    snippets::lowered::LinearIR body;
+};
+
+}   // namespace aarch64
+}   // namespace intel_cpu
+}   // namespace ov

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_fill_emitter.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_fill_emitter.cpp
@@ -1,0 +1,97 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "jit_fill_emitter.hpp"
+#include "cpu/aarch64/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_adr.h"
+
+using namespace Xbyak_aarch64;
+
+namespace ov {
+namespace intel_cpu {
+namespace aarch64 {
+
+using jit_generator = dnnl::impl::cpu::aarch64::jit_generator;
+using cpu_isa_t = dnnl::impl::cpu::aarch64::cpu_isa_t;
+using ExpressionPtr = ov::snippets::lowered::ExpressionPtr;
+
+FillEmitter::FillEmitter(jit_generator* h, cpu_isa_t isa, const ExpressionPtr& expr)
+    : jit_emitter(h, isa, ov::element::f32, emitter_in_out_map::vec_to_vec) {
+    const auto fill = ov::as_type_ptr<snippets::op::Fill>(expr->get_node());
+    if (fill->get_element_type().size() != 4) {
+        OPENVINO_THROW("Fill emitter supports only 4 Byte element types but gets: ", fill->get_element_type());
+    }
+
+    offset = fill->get_offset();
+    fill_value = fill->get_fill_value();
+    if (!is_optimized())
+        push_arg_entry_of("value", fill_value, true);
+    prepare_table();
+}
+
+size_t FillEmitter::get_aux_gprs_count() const {
+    // Optimized version (fill full vector by zero) doesn't need additional register
+    if (is_optimized())
+        return 0;
+
+    return 1;
+}
+
+void FillEmitter::emit_impl(const std::vector<size_t>& in,
+                            const std::vector<size_t>& out) const {
+    if (host_isa_ == dnnl::impl::cpu::aarch64::asimd) {
+        emit_isa<dnnl::impl::cpu::aarch64::asimd>(in, out);
+    } else {
+        OPENVINO_THROW("Fill emitter doesn't support ", host_isa_);
+    }
+}
+
+template <cpu_isa_t isa>
+void FillEmitter::emit_isa(const std::vector<size_t> &in, const std::vector<size_t> &out) const {
+    if (is_full_reg())
+        fill_full<dnnl::impl::cpu::aarch64::asimd>(out);
+    else
+        fill_tail<dnnl::impl::cpu::aarch64::asimd>(in, out);
+}
+
+template <cpu_isa_t isa>
+void FillEmitter::fill_full(const std::vector<size_t> &out) const {
+    using TReg = typename dnnl::impl::cpu::aarch64::cpu_isa_traits<isa>::TReg;
+    TReg dst = TReg(out[0]);
+
+    // Optimized impl for zero
+    if (is_optimized()) {
+        h->uni_clear(dst);
+        return;
+    }
+
+    AdrImm src = table_val("value");
+    h->uni_ld1rw(dst.s, src.getXn(), src.getImm());
+}
+
+template <cpu_isa_t isa>
+void FillEmitter::fill_tail(const std::vector<size_t> &in, const std::vector<size_t> &out) const {
+    using TReg = typename dnnl::impl::cpu::aarch64::cpu_isa_traits<isa>::TReg;
+    TReg dst = TReg(out[0]);
+
+    switch (offset) {
+        case 1:
+            h->ld1(dst.s[1], table_val2("value", sizeof(float)));
+            h->ld1(dst.d[1], table_val2("value", 2 * sizeof(float)));
+            break;
+        case 2:
+            h->ld1(dst.d[1], table_val2("value", 2 * sizeof(float)));
+            break;
+        case 3:
+            h->ld1(dst.s[3], table_val2("value", 3 * sizeof(float)));
+            break;
+        case 4:
+            break;
+        default:
+            OPENVINO_THROW("Fill emitter has unexpected offset: ", offset);
+    }
+}
+
+}   // namespace aarch64
+}   // namespace intel_cpu
+}   // namespace ov

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_fill_emitter.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_fill_emitter.hpp
@@ -1,0 +1,44 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "emitters/plugin/aarch64/jit_emitter.hpp"
+
+namespace ov {
+namespace intel_cpu {
+namespace aarch64 {
+
+class FillEmitter : public jit_emitter {
+public:
+    FillEmitter(dnnl::impl::cpu::aarch64::jit_generator* h,
+                dnnl::impl::cpu::aarch64::cpu_isa_t isa,
+                const ov::snippets::lowered::ExpressionPtr& expr);
+
+    size_t get_inputs_count() const override {return 1;}
+
+protected:
+    size_t get_aux_gprs_count() const override;
+
+private:
+    void emit_impl(const std::vector<size_t>& in,
+                   const std::vector<size_t>& out) const override;
+
+    template <dnnl::impl::cpu::aarch64::cpu_isa_t isa>
+    void emit_isa(const std::vector<size_t> &in, const std::vector<size_t> &out) const;
+    template <dnnl::impl::cpu::aarch64::cpu_isa_t isa>
+    void fill_full(const std::vector<size_t> &out) const;
+    template <dnnl::impl::cpu::aarch64::cpu_isa_t isa>
+    void fill_tail(const std::vector<size_t> &in, const std::vector<size_t> &out) const;
+
+    bool is_full_reg() const { return offset == 0; }
+    bool is_optimized() const { return is_full_reg() && fill_value == uint32_t(0x0); }
+
+    size_t offset = 0;
+    uint32_t fill_value = 0x0;
+};
+
+}   // namespace aarch64
+}   // namespace intel_cpu
+}   // namespace ov

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_kernel_emitter.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_kernel_emitter.cpp
@@ -1,0 +1,266 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "jit_kernel_emitter.hpp"
+
+using namespace Xbyak_aarch64;
+
+namespace ov {
+namespace intel_cpu {
+namespace aarch64 {
+
+using jit_generator = dnnl::impl::cpu::aarch64::jit_generator;
+using cpu_isa_t = dnnl::impl::cpu::aarch64::cpu_isa_t;
+using ExpressionPtr = ov::snippets::lowered::ExpressionPtr;
+
+inline static std::vector<XReg> transform_idxs_to_regs(const std::vector<size_t>& idxs) {
+    std::vector<XReg> regs;
+    regs.resize(idxs.size(), XReg(0));
+    std::transform(idxs.begin(), idxs.end(), regs.begin(), [](size_t idx){return XReg(idx);});
+    return regs;
+}
+
+inline static std::vector<size_t> transform_snippets_regs_to_idxs(const std::vector<snippets::Reg>& regs) {
+    std::vector<size_t> idxs(regs.size());
+    std::transform(regs.cbegin(), regs.cend(), idxs.begin(), [](const snippets::Reg& reg) { return reg.idx; });
+    return idxs;
+}
+
+inline static void push_XReg(dnnl::impl::cpu::aarch64::jit_generator *h, uint32_t xreg_idx) {
+    h->str(Xbyak_aarch64::XReg(xreg_idx), pre_ptr(h->sp, -16));
+}
+
+inline void pop_XReg(dnnl::impl::cpu::aarch64::jit_generator *h, uint32_t xreg_idx) {
+    h->ldr(Xbyak_aarch64::XReg(xreg_idx), post_ptr(h->sp, 16));
+}
+
+KernelEmitter::KernelEmitter(jit_generator* h, cpu_isa_t isa, const ExpressionPtr& expr)
+    : jit_container_emitter(h, isa, expr),
+      reg_indexes_idx(Operand::X0),
+      reg_const_params_idx(Operand::X1) {
+    const auto kernel = ov::as_type_ptr<snippets::op::Kernel>(expr->get_node());
+    if (!kernel)
+        OPENVINO_THROW("KernelEmitter invoked with invalid op argument");
+    if (kernel->region.empty())
+        OPENVINO_THROW("KernelEmitter invoked with empty body");
+    if (kernel->compile_params == nullptr)
+        OPENVINO_THROW("KernelEmitter invoked with op::Kernel that contains no compile_params");
+    body = kernel->region;
+    jcp = *reinterpret_cast<const jit_snippets_compile_args*>(kernel->compile_params);
+    master_shape = body.get_master_shape();
+    // Note: plugin can prepend master shape with 1 to facilitate parallel execution (usually up to 6D tensor)
+    //       so we have to reproduce this behavior here
+    master_shape.insert(master_shape.begin(), jcp.parallel_executor_ndims - master_shape.size(), 1);
+    const auto& io_exprs = body.get_IO_ops();
+    num_inputs = 0;
+    num_outputs = 0;
+    for (const auto& expr : io_exprs) {
+        snippets::lowered::PortDescriptorPtr desc = nullptr;
+        element::Type etype;
+        switch (expr->get_type()) {
+            case snippets::lowered::IOExpression::io_type::INPUT: {
+                const auto first_consumer = expr->get_output_port_connector(0)->get_consumers().begin()->get_expr();
+                if (ov::is_type<snippets::op::RankNormalization>(first_consumer->get_node())) {
+                    desc = first_consumer->get_output_port_descriptor(0);
+                } else {
+                    desc = expr->get_output_port_descriptor(0);
+                }
+                etype = expr->get_node()->get_output_element_type(0);
+                num_inputs++;
+                break;
+            }
+            case snippets::lowered::IOExpression::io_type::OUTPUT: {
+                num_outputs++;
+                desc = expr->get_input_port_descriptor(0);
+                etype = expr->get_node()->get_input_element_type(0);
+                break;
+            } default : {
+                OPENVINO_THROW("Kernel detected unsupported io_type");
+            }
+        }
+        const auto& shape = desc->get_shape();
+        const auto& layout = desc->get_layout();
+        OPENVINO_ASSERT(shape.size() == layout.size(), "Shape and layout must have the same length");
+        const auto max_dim = *std::max_element(layout.begin(), layout.end());
+        OPENVINO_ASSERT(max_dim < shape.size(), "Max layout index can't be larger than the shape size");
+        io_shapes.push_back(shape);
+        io_data_layouts.push_back(layout);
+        io_data_sizes.push_back(etype.size());
+    }
+
+    // Initialize pools of gp and vec registers
+    gp_regs_pool.resize(16);
+    vec_regs_pool.resize(16);
+    // It's easier to remove the last item during mapping, so fill descending to map ascending
+    for (size_t i = 0; i < 16; i++)
+        gp_regs_pool[i] = vec_regs_pool[i] = 15 - i;
+    // todo: it's more convenient to use std::set as a pool container (unique and always sorted),
+    //  but pools are vectors to align with emit_code signature. Change signature?
+    auto remove_regs_from_pool = [](std::vector<size_t>& pool, const std::set<size_t>& to_remove) {
+        // It's important to keep the order of other elements
+        pool.erase(std::remove_if(pool.begin(), pool.end(),
+                                       [&](size_t x) {return to_remove.count(x) != 0;}), pool.end());
+    };
+    // Reserve reg_indexes_idx and reg_const_params_idx, since they'll be used to pass runtime call args to kernel
+    remove_regs_from_pool(gp_regs_pool, {reg_indexes_idx, reg_const_params_idx});
+
+    mapping_info gpr_map_pool({}, gp_regs_pool);
+    mapping_info vec_map_pool({}, vec_regs_pool);
+    snippets::lowered::LinearIR::container mem_access_exprs;
+    snippets::lowered::LinearIR::container general_exprs;
+    std::set<size_t> unique_buffers;
+
+    for (const auto& expr : body) {
+        // Brgemm is a special case since it incorporates input and output (we use onednn kernel)
+        // Just like Load & Store it requires offsets calculation
+        if (std::dynamic_pointer_cast<snippets::lowered::IOExpression>(expr)) {
+            mem_access_exprs.emplace_back(expr);
+        } else if (const auto buffer = ov::as_type_ptr<snippets::op::Buffer>(expr->get_node())) {
+            const auto buffer_id = buffer->get_id();
+            if (unique_buffers.count(buffer_id) == 0) {
+                mem_access_exprs.push_back(expr);
+                unique_buffers.insert(buffer_id);
+            }
+        } else {
+            general_exprs.emplace_back(expr);
+        }
+    }
+    num_unique_buffers = unique_buffers.size();
+
+    // Note that we can't use reg_indexes_idx or reg_const_params_idx to store data pointers because these two
+    // regs are used to calculate offsets for the data pointers
+    map_abstract_registers(gpr_map_pool, vec_map_pool, mem_access_exprs);
+    for (const auto& abstract_to_physical : gpr_map_pool.first)
+        data_ptr_regs_idx.push_back(abstract_to_physical.second);
+    // However we can use reg_indexes_idx and reg_const_params_idx for other operations since we won't need them
+    // after offsets calculation
+    gpr_map_pool.second.push_back(reg_indexes_idx);
+    gpr_map_pool.second.push_back(reg_const_params_idx);
+    map_abstract_registers(gpr_map_pool, vec_map_pool, general_exprs);
+}
+
+void KernelEmitter::emit_code(const std::vector<size_t> &in,
+                              const std::vector<size_t> &out) const {
+    validate_arguments(in, out);
+    emit_impl(in, out);
+}
+
+void KernelEmitter::validate_arguments(const std::vector<size_t> &in,
+                                       const std::vector<size_t> &out) const {
+    if (!in.empty())
+        OPENVINO_THROW("KernelEmitter got invalid number of inputs. Expected 0, got ", in.size());
+    if (!out.empty())
+        OPENVINO_THROW("KernelEmitter got invalid number of outputs. Expected 0, got ", out.size());
+    const auto num_params = num_inputs + num_outputs + num_unique_buffers;
+    // The number of used gpr may be >= num_params since LoopBegin+LoopEnd could also use gpr to store work_amount
+    if (data_ptr_regs_idx.size() != num_params)
+        OPENVINO_THROW(
+            "KernelEmitter: number of inputs and outputs is inconsistent with the number of allocated registers ",
+            num_params,
+            " data_ptr_regs_idx.size() = ",
+            data_ptr_regs_idx.size());
+}
+
+void KernelEmitter::emit_impl(const std::vector<size_t>& in,
+                              const std::vector<size_t>& out) const {
+    h->preamble();
+
+    XReg reg_indexes = XReg(reg_indexes_idx);
+    XReg reg_const_params = XReg(reg_const_params_idx);
+    auto data_ptr_regs = transform_idxs_to_regs(data_ptr_regs_idx);
+
+    init_data_pointers(reg_indexes, reg_const_params, data_ptr_regs);
+    for (const auto& expression : body) {
+        const auto reg_info = expression->get_reg_info();
+        const auto in_regs = transform_snippets_regs_to_idxs(reg_info.first);
+        const auto out_regs = transform_snippets_regs_to_idxs(reg_info.second);
+        const auto& emitter = expression->get_emitter();
+        emitter->emit_code(in_regs, out_regs, vec_regs_pool, gp_regs_pool);
+    }
+    h->postamble();
+}
+
+void KernelEmitter::init_data_pointers(const XReg& reg_indexes, const XReg& reg_const_params,
+                                       const std::vector<XReg>& data_ptr_regs) const {
+    // X19~X28 are Callee-saved registers. Their contents must be saved before usage and restored afterwards.
+    push_XReg(h, 19);
+    push_XReg(h, 20);
+    XReg reg_tmp = XReg(19);
+    XReg reg_aux = XReg(20);
+
+    const auto num_params = num_inputs + num_outputs;
+    // Note that we don't need offset for the last dim, since it's handled directly by Tile emitter
+    const size_t offset_rank = master_shape.size() - 1;
+    std::vector<std::vector<size_t>> data_offsets(num_params, std::vector<size_t>{});
+    auto offset_calculation = [=](const std::vector<size_t>& shape, const std::vector<size_t>& layout, const size_t data_size, bool is_input) {
+        // Strides represent distance between consecutive elements of corresponding dimension.
+        // If a dim size == 1, then the next dim starts immediately and the stride is 0
+        // case 1:
+        //    shape:         s0,    s1, s2, s3
+        //    strides: s1*s2*s3, s2*s3, s3,  1
+        // case 2:
+        //    shape:      s0, s1, s2 == 1, s3
+        //    strides: s1*s3, s3,       0,  1
+        std::vector<size_t> strides(shape.size());
+        size_t dim_step = 1;
+        strides[shape.size() - 1] = 1;
+        for (int k = static_cast<int>(shape.size()) - 2; k >= 0; k--) {
+            dim_step *= shape[k+1];
+            strides[k] = shape[k] != 1 ? dim_step * data_size : 0;
+        }
+        // Note: this is an extra copy, but let's keep it for clarity
+        if (!layout.empty()) {
+            std::vector<size_t> reordered_strides(strides.size());
+            for (size_t i = 0; i < layout.size(); i++) {
+                const auto& src_idx = is_input ? layout[i] : i;
+                const auto& dst_idx = is_input ? i : layout[i];
+                reordered_strides[dst_idx] = strides[src_idx];
+            }
+            strides = std::move(reordered_strides);
+        }
+        // the last stride is ignored, since the entire last dim is processed by kernel
+        // and no parallel_for data_ptr offsets can be applied in this case
+        strides.pop_back();
+        // actual offset size might be larger that the shape size due to 6D scheduling
+        strides.insert(strides.begin(), offset_rank - strides.size(), 0);
+
+        return strides;
+    };
+    for (size_t i = 0; i < num_params; i++) {
+        data_offsets[i] = offset_calculation(io_shapes[i],  io_data_layouts[i], io_data_sizes[i], i < num_inputs);
+    }
+    // master_shape size must be valid in both static and dynamic cases
+    auto init_ptr_with_offset = [&](XReg pointer, const std::vector<size_t>& offsets) {
+        for (size_t j = 0; j < offset_rank; j++) {
+            if (master_shape[j] != 1 && offsets[j] != 0) {
+                h->mov(reg_tmp, offsets[j]);
+                h->ldr(reg_aux, ptr(reg_indexes, static_cast<int32_t>(j * sizeof(size_t))));
+                h->mul(reg_tmp, reg_tmp, reg_aux);
+                h->add(pointer, pointer, reg_tmp);
+            }
+        }
+    };
+    // Vector "data_ptr_regs" is sorted by abstract regs.
+    // It means that the vector contains the physical registers in order [src, .., src, dst, .., dst, buffer]
+    // So we can initialize buffer register firstly as last value of vector "data_ptr_regs"
+    // NOTE: Snippets Buffer Scratchpad has the common data pointer for all Buffers (even with different ID).
+    //       The accessing memory is covered by correct offsets in each Buffer and the corresponding MemoryAccess ops
+    for (size_t i = 0; i < num_unique_buffers; ++i) {
+        h->ldr(data_ptr_regs[num_params + i], ptr(reg_const_params, static_cast<int32_t>(GET_OFF(buffer_scratchpad_ptr))));
+    }
+    for (size_t i = 0; i < num_params; i++) {
+        if (i < num_inputs)
+            h->ldr(data_ptr_regs[i], ptr(reg_const_params, static_cast<int32_t>(GET_OFF(src_ptrs) + i * sizeof(void*))));
+        else
+            h->ldr(data_ptr_regs[i], ptr(reg_const_params, static_cast<int32_t>(GET_OFF(dst_ptrs) + (i - num_inputs) * sizeof(void*))));
+        init_ptr_with_offset(data_ptr_regs[i], data_offsets[i]);
+    }
+
+    pop_XReg(h, 20);
+    pop_XReg(h, 19);
+}
+
+}   // namespace aarch64
+}   // namespace intel_cpu
+}   // namespace ov

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_kernel_emitter.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_kernel_emitter.hpp
@@ -1,0 +1,83 @@
+
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "emitters/plugin/aarch64/jit_emitter.hpp"
+#include "jit_container_emitter.hpp"
+
+namespace ov {
+namespace intel_cpu {
+namespace aarch64 {
+
+#define SNIPPETS_MAX_SNIPPETS_DIMS 12
+#define GET_OFF(field) offsetof(jit_snippets_call_args, field)
+
+struct jit_snippets_call_args {
+    const void *src_ptrs[SNIPPETS_MAX_SNIPPETS_DIMS] = {};
+    void *dst_ptrs[SNIPPETS_MAX_SNIPPETS_DIMS] = {};
+    void *buffer_scratchpad_ptr = nullptr;
+};
+
+struct jit_snippets_compile_args {
+    size_t parallel_executor_ndims = 1;
+};
+
+/// \brief  Kernel is the only entry point to Codogen Jit compilation. Kernel perform abstract-to-physical register
+/// mapping and creates a pools of available gpr and vec registers. Kernel usually contains (at least one)
+/// LoopBeginEmitter and LoopEndEmitter pair. In general the enclosed emitters should be organized in the following way:
+/// KernelEmitter {                 /* entry point, maps registers, creates pools of available registers */
+///     1.S LoopBeginEmitter        /* Scalar Loop over the outer dimension [START] */
+///         2.S LoopBeginEmitter    /* inner vector loop [START] */
+///             ...                 /* All the necessary Load/Strore/elementwise emitters */
+///         2.E LoopEndEmitter      /* inner vector loop [END] */
+///         3.S LoopBeginEmitter    /* inner scalar loop for tail processing [START]*/
+///             ...                 /* All the necessary Load/Strore/elementwise emitters */
+///         3.E LoopEndEmitter      /* inner scalar loop for tail processing [END]*/
+///     1.E LoopEndEmitter          /* Scalar Loop over the outer dimension [END] */
+/// }
+/// Note that Kernel doesn't accept any input arguments.
+class KernelEmitter : public jit_container_emitter {
+public:
+    KernelEmitter(dnnl::impl::cpu::aarch64::jit_generator* h,
+                  dnnl::impl::cpu::aarch64::cpu_isa_t isa,
+                  const ov::snippets::lowered::ExpressionPtr& expr);
+
+    void emit_code(const std::vector<size_t> &in,
+                   const std::vector<size_t> &out) const;
+    size_t get_inputs_count() const override {return 0;}
+
+private:
+    using jit_emitter::emit_code;
+    void validate_arguments(const std::vector<size_t> &in,
+                            const std::vector<size_t> &out) const override;
+    void emit_impl(const std::vector<size_t>& in,
+                   const std::vector<size_t>& out) const override;
+    void init_data_pointers(const Xbyak_aarch64::XReg&, const Xbyak_aarch64::XReg&, const std::vector<Xbyak_aarch64::XReg>&) const;
+
+    jit_snippets_compile_args jcp;
+    std::vector<size_t> gp_regs_pool;
+    std::vector<size_t> master_shape;
+    size_t num_inputs;
+    size_t num_outputs;
+    size_t num_unique_buffers;
+    // Vector of indices (length = input tensor rank) per every input and output that describes in which order
+    // corresponding tensor dimensions are accessed (default: consecutive dense, e.g. 0,1,2,3 for 4D tensor).
+    // Needed to calc i/o offsets.
+    std::vector<std::vector<size_t>> io_data_layouts;
+    std::vector<std::vector<size_t>> io_shapes = {};
+    std::vector<size_t> io_data_sizes {};
+
+    // gpr's used to store data pointers, track them to apply offsets in Kernel
+    std::vector<size_t> data_ptr_regs_idx;
+    std::vector<size_t> vec_regs_pool;
+
+    const size_t reg_indexes_idx;
+    const size_t reg_const_params_idx;
+};
+
+}   // namespace aarch64
+}   // namespace intel_cpu
+}   // namespace ov

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_loop_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_loop_emitters.cpp
@@ -1,0 +1,154 @@
+// Copyright (C) 2020-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "jit_loop_emitters.hpp"
+
+using namespace Xbyak_aarch64;
+
+namespace ov {
+namespace intel_cpu {
+namespace aarch64 {
+
+using jit_generator = dnnl::impl::cpu::aarch64::jit_generator;
+using cpu_isa_t = dnnl::impl::cpu::aarch64::cpu_isa_t;
+using ExpressionPtr = ov::snippets::lowered::ExpressionPtr;
+
+LoopBeginEmitter::LoopBeginEmitter(jit_generator* h, cpu_isa_t isa, const ExpressionPtr& expr) : jit_emitter(h, isa) {
+    loop_begin = ov::as_type_ptr<snippets::op::LoopBegin>(expr->get_node());
+    if (!loop_begin)
+        OPENVINO_THROW("LoopBeginEmitter invoked with invalid op argument");
+    const auto& target_inputs = loop_begin->output(loop_begin->get_output_size() - 1).get_target_inputs();
+    if (target_inputs.size() != 1)
+        OPENVINO_THROW("LoopBeginEmitter invoked with invalid configuration: the last output must have exactly one "
+                       "input attached");
+    const auto loop_end = ov::as_type_ptr<snippets::op::LoopEnd>(target_inputs.begin()->get_node()->shared_from_this());
+    if (!loop_end)
+        OPENVINO_THROW("LoopBeginEmitter invoked with invalid configuration: the last output must be LoopEnd");
+    work_amount = loop_end->get_work_amount();
+    evaluate_once = loop_end->get_evaluate_once();
+    in_out_type_ = emitter_in_out_map::gpr_to_gpr;
+}
+
+void LoopBeginEmitter::emit_code(const std::vector<size_t> &in,
+                                 const std::vector<size_t> &out) const {
+    validate_arguments(in, out);
+    emit_impl(in, out);
+}
+
+void LoopBeginEmitter::validate_arguments(const std::vector<size_t> &in,
+                                          const std::vector<size_t> &out) const {
+    if (!in.empty())
+        OPENVINO_THROW("Invalid inputs size: expected 0 got ", in.size());
+    if (out.size() != 1)
+        OPENVINO_THROW("Invalid outputs size: expected 1 got ", out.size());
+}
+
+void LoopBeginEmitter::emit_impl(const std::vector<size_t>& in,
+                                 const std::vector<size_t>& out) const {
+    if (host_isa_ == dnnl::impl::cpu::aarch64::asimd) {
+        emit_isa<dnnl::impl::cpu::aarch64::asimd>(in, out);
+    } else {
+        OPENVINO_THROW("LoopBegin emitter doesn't support ", host_isa_);
+    }
+}
+
+template <cpu_isa_t isa>
+void LoopBeginEmitter::emit_isa(const std::vector<size_t>& in,
+                                const std::vector<size_t>& out) const {
+    XReg reg_work_amount = XReg(out[0]);
+
+    // save previous register state (if there is an outer loop that uses this reg for example)
+    if (!evaluate_once) {
+        h->mov(reg_work_amount, work_amount);
+    }
+    // Note: loop address is not calculated at this point, so need to call calcJmpAddress() which is protected
+    // or ready(), but they both set internal flags and that's not a desired way to use them.
+    // So the most obvious WA is just to use current address manually
+    loop_begin->begin_address = h->getCurr();
+}
+
+LoopEndEmitter::LoopEndEmitter(jit_generator* h, cpu_isa_t isa, const ExpressionPtr& expr) : jit_emitter(h, isa) {
+    loop_end = ov::as_type_ptr<snippets::op::LoopEnd>(expr->get_node());
+    if (!loop_end)
+        OPENVINO_THROW("LoopEndEmitter invoked with invalid op argument");
+    loop_begin = loop_end->get_loop_begin();
+    if (!loop_begin)
+        OPENVINO_THROW("LoopEndEmitter invoked with invalid configuration: the last arg must be LoopBegin");
+    num_inputs = loop_end->get_input_num();
+    num_outputs = loop_end->get_output_num();
+    wa_increment = static_cast<int64_t>(loop_end->get_increment());
+    work_amount = static_cast<int64_t>(loop_end->get_work_amount());
+    is_incremented = loop_end->get_is_incremented();
+    ptr_increments = loop_end->get_ptr_increments();
+    finalization_offsets = loop_end->get_finalization_offsets();
+    evaluate_once = loop_end->get_evaluate_once();
+    io_data_size = loop_end->get_element_type_sizes();
+    in_out_type_ = emitter_in_out_map::gpr_to_gpr;
+}
+
+void LoopEndEmitter::emit_code(const std::vector<size_t> &in,
+                               const std::vector<size_t> &out) const {
+    validate_arguments(in, out);
+    emit_impl(in, out);
+}
+
+void LoopEndEmitter::validate_arguments(const std::vector<size_t> &in,
+                                        const std::vector<size_t> &out) const {
+    if (out.size() != num_outputs)
+        OPENVINO_THROW("Invalid number of out arguments: expected ", num_outputs, " got ", out.size());
+    if (in.size() != num_inputs)
+        OPENVINO_THROW("Invalid number of in arguments: expected ", num_inputs , " got ", in.size());
+    const auto io_size = num_inputs - 1;
+    if (ptr_increments.size() != io_size)
+        OPENVINO_THROW("Invalid ptr_increments size: expected ", io_size, " got ", ptr_increments.size());
+    if (finalization_offsets.size() != io_size)
+        OPENVINO_THROW("Invalid finalization_offsets size: expected: ", io_size, " got ", finalization_offsets.size());
+}
+
+void LoopEndEmitter::emit_impl(const std::vector<size_t>& in,
+                               const std::vector<size_t>& out) const {
+    if (host_isa_ == dnnl::impl::cpu::aarch64::asimd) {
+        emit_isa<dnnl::impl::cpu::aarch64::asimd>(in, out);
+    } else {
+        OPENVINO_THROW("LoopEnd emitter doesn't support ", host_isa_);
+    }
+}
+
+template <cpu_isa_t isa>
+void LoopEndEmitter::emit_isa(const std::vector<size_t>& in,
+                              const std::vector<size_t>& out) const {
+    std::vector<size_t> data_ptr_reg_idxs;
+    // the last input is actually a work_amount reg
+    data_ptr_reg_idxs.reserve(num_inputs - 1);
+    std::copy(in.begin(), in.end() - 1, std::back_inserter(data_ptr_reg_idxs));
+
+    XReg reg_work_amount = XReg(in.back());
+    if (!evaluate_once) {
+        for (size_t idx = 0; idx < data_ptr_reg_idxs.size(); idx++) {
+            if (!is_incremented[idx] || ptr_increments[idx] == 0)
+                continue;
+            XReg data_reg = XReg(data_ptr_reg_idxs[idx]);
+            if (ptr_increments[idx] > 0) {
+                h->add(data_reg, data_reg, ptr_increments[idx] * wa_increment * io_data_size[idx]);
+            } else if (ptr_increments[idx] < 0) {
+                h->sub(data_reg, data_reg, - ptr_increments[idx] * wa_increment * io_data_size[idx]);
+            }
+        }
+        h->sub(reg_work_amount, reg_work_amount, wa_increment);
+        h->cmp(reg_work_amount, wa_increment);
+        h->b(GE, reinterpret_cast<int64_t>(loop_begin->begin_address) - reinterpret_cast<int64_t>(h->getCurr()));
+    }
+
+    for (size_t idx = 0; idx < data_ptr_reg_idxs.size(); idx++) {
+        if (!is_incremented[idx] || finalization_offsets[idx] == 0)
+            continue;
+
+        XReg data_reg = XReg(data_ptr_reg_idxs[idx]);
+        h->add(data_reg, data_reg, finalization_offsets[idx] * io_data_size[idx]);
+    }
+}
+
+}   // namespace aarch64
+}   // namespace intel_cpu
+}   // namespace ov

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_loop_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_loop_emitters.hpp
@@ -1,0 +1,76 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "emitters/plugin/aarch64/jit_emitter.hpp"
+
+namespace ov {
+namespace intel_cpu {
+namespace aarch64 {
+
+class LoopBeginEmitter : public jit_emitter {
+public:
+    LoopBeginEmitter(dnnl::impl::cpu::aarch64::jit_generator* h,
+                     dnnl::impl::cpu::aarch64::cpu_isa_t isa,
+                     const ov::snippets::lowered::ExpressionPtr& expr);
+
+    void emit_code(const std::vector<size_t> &in,
+                   const std::vector<size_t> &out) const;
+    size_t get_inputs_count() const override {return 0;}
+
+private:
+    using jit_emitter::emit_code;
+    void validate_arguments(const std::vector<size_t> &in,
+                            const std::vector<size_t> &out) const override;
+    void emit_impl(const std::vector<size_t>& in,
+                   const std::vector<size_t>& out) const override;
+    template <dnnl::impl::cpu::aarch64::cpu_isa_t isa>
+    void emit_isa(const std::vector<size_t>& in,
+                  const std::vector<size_t>& out) const;
+
+    std::shared_ptr<snippets::op::LoopBegin> loop_begin;
+    bool evaluate_once = false;
+    size_t work_amount = 0;
+};
+
+class LoopEndEmitter : public jit_emitter {
+public:
+    LoopEndEmitter(dnnl::impl::cpu::aarch64::jit_generator* h,
+                   dnnl::impl::cpu::aarch64::cpu_isa_t isa,
+                   const ov::snippets::lowered::ExpressionPtr& expr);
+
+    void emit_code(const std::vector<size_t> &in,
+                   const std::vector<size_t> &out) const;
+    size_t get_inputs_count() const override {return 0;}
+
+private:
+    using jit_emitter::emit_code;
+    void validate_arguments(const std::vector<size_t> &in,
+                            const std::vector<size_t> &out) const override;
+
+    void emit_impl(const std::vector<size_t>& in,
+                   const std::vector<size_t>& out) const override;
+    template <dnnl::impl::cpu::aarch64::cpu_isa_t isa>
+    void emit_isa(const std::vector<size_t>& in,
+                  const std::vector<size_t>& out) const;
+
+    std::shared_ptr<snippets::op::LoopBegin> loop_begin;
+    std::shared_ptr<snippets::op::LoopEnd> loop_end;
+
+    size_t num_inputs = 0;
+    size_t num_outputs = 0;
+    // keep data_size int64_t to avoid conversion to size_t (and overflow) when multiplied by negative increments or offsets
+    std::vector<int64_t> io_data_size {};
+    int64_t wa_increment = 0;
+    int64_t work_amount = 0;
+    bool evaluate_once = false;
+    std::vector<bool> is_incremented;
+    std::vector<int64_t> ptr_increments;
+    std::vector<int64_t> finalization_offsets;
+};
+
+}   // namespace aarch64
+}   // namespace intel_cpu
+}   // namespace ov

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_memory_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_memory_emitters.cpp
@@ -1,0 +1,140 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "jit_memory_emitters.hpp"
+
+using namespace Xbyak_aarch64;
+
+namespace ov {
+namespace intel_cpu {
+namespace aarch64 {
+
+using jit_generator = dnnl::impl::cpu::aarch64::jit_generator;
+using cpu_isa_t = dnnl::impl::cpu::aarch64::cpu_isa_t;
+using ExpressionPtr = ov::snippets::lowered::ExpressionPtr;
+
+static std::vector<size_t> convert_to_size_t(const std::vector<uint32_t>& vec_in) {
+    std::vector<size_t> vec_out;
+    for (const auto& in : vec_in) {
+        vec_out.push_back(static_cast<size_t>(in));
+    }
+    return vec_out;
+}
+
+MemoryEmitter::MemoryEmitter(jit_generator* h, cpu_isa_t isa, const ExpressionPtr& expr) : jit_emitter(h, isa) {
+    const auto n = expr->get_node();
+    src_prc = n->get_input_element_type(0);
+    dst_prc = n->get_output_element_type(0);
+}
+
+jit_load_memory_emitter::jit_load_memory_emitter(jit_generator* h, cpu_isa_t isa, const ExpressionPtr& expr) : MemoryEmitter(h, isa, expr) {
+    if (src_prc != dst_prc)
+        OPENVINO_THROW("jit_load_memory_emitter supports only equal input and output types but gets: ",
+                       src_prc.get_type_name(),
+                       " and ",
+                       dst_prc.get_type_name());
+    if (src_prc != ov::element::f32)
+        OPENVINO_THROW("jit_load_memory_emitter only supports FP32 precision.");
+
+    const auto load = std::dynamic_pointer_cast<snippets::op::Load>(expr->get_node());
+    count = load->get_count();
+    byte_offset = load->get_offset();
+    in_out_type_ = emitter_in_out_map::gpr_to_vec;
+    load_emitter.reset(new jit_load_emitter(h, isa, src_prc, dst_prc, count, byte_offset));
+}
+
+void jit_load_memory_emitter::emit_impl(const std::vector<size_t>& in,
+                            const std::vector<size_t>& out) const {
+    if (host_isa_ == dnnl::impl::cpu::aarch64::asimd) {
+        emit_isa<dnnl::impl::cpu::aarch64::asimd>(in, out);
+    } else {
+        OPENVINO_THROW("Load emitter doesn't support ", host_isa_);
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_load_memory_emitter::emit_isa(const std::vector<size_t> &in, const std::vector<size_t> &out) const {
+    if (!load_emitter)
+        OPENVINO_THROW("Load CPU emitter isn't initialized for jit_load_memory_emitter!");
+
+    load_emitter->emit_code(in, out, convert_to_size_t(aux_vec_idxs), convert_to_size_t(aux_gpr_idxs));
+}
+
+void jit_load_memory_emitter::emit_data() const {
+    load_emitter->emit_data();
+}
+
+jit_load_broadcast_emitter::jit_load_broadcast_emitter(jit_generator* h, cpu_isa_t isa, const ExpressionPtr& expr)
+    : MemoryEmitter(h, isa, expr) {
+    if (src_prc != dst_prc)
+        OPENVINO_THROW("BroadcastEmitters support only equal input and output types but gets: ",
+                       src_prc.get_type_name(),
+                       " and ",
+                       dst_prc.get_type_name());
+    if (src_prc != ov::element::f32)
+        OPENVINO_THROW("jit_load_broadcast_emitter only supports FP32 precision.");
+
+    const auto broadcast_load = std::dynamic_pointer_cast<snippets::op::BroadcastLoad>(expr->get_node());
+    byte_offset = broadcast_load->get_offset();
+    in_out_type_ = emitter_in_out_map::gpr_to_vec;
+}
+
+void jit_load_broadcast_emitter::emit_impl(const std::vector<size_t>& in,
+                                     const std::vector<size_t>& out) const {
+    if (host_isa_ == dnnl::impl::cpu::aarch64::asimd) {
+        emit_isa<dnnl::impl::cpu::aarch64::asimd>(in, out);
+    } else {
+        OPENVINO_THROW("BroadcastLoad emitter doesn't support ", host_isa_);
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_load_broadcast_emitter::emit_isa(const std::vector<size_t> &in, const std::vector<size_t> &out) const {
+    using TReg = typename dnnl::impl::cpu::aarch64::cpu_isa_traits<isa>::TReg;
+    XReg src = XReg(in[0]);
+    TReg dst = TReg(out[0]);
+
+    h->uni_ld1rw(dst.s, src, byte_offset);
+}
+
+jit_store_memory_emitter::jit_store_memory_emitter(jit_generator* h, cpu_isa_t isa, const ExpressionPtr& expr) : MemoryEmitter(h, isa, expr) {
+    if (src_prc != dst_prc)
+        OPENVINO_THROW("jit_store_memory_emitter supports only equal input and output types but gets: ",
+                       src_prc.get_type_name(),
+                       " and ",
+                       dst_prc.get_type_name());
+    if (src_prc != ov::element::f32)
+        OPENVINO_THROW("jit_store_memory_emitter only supports FP32 precision.");
+
+    const auto store = ov::as_type_ptr<snippets::op::Store>(expr->get_node());
+    count = store->get_count();
+    byte_offset = store->get_offset();
+    in_out_type_ = emitter_in_out_map::vec_to_gpr;
+    store_emitter.reset(new jit_store_emitter(h, isa, src_prc, dst_prc, count, byte_offset));
+}
+
+void jit_store_memory_emitter::emit_impl(const std::vector<size_t>& in,
+                             const std::vector<size_t>& out) const {
+    if (host_isa_ == dnnl::impl::cpu::aarch64::asimd) {
+        emit_isa<dnnl::impl::cpu::aarch64::asimd>(in, out);
+    } else {
+        OPENVINO_THROW("Store emitter doesn't support ", host_isa_);
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_store_memory_emitter::emit_isa(const std::vector<size_t> &in, const std::vector<size_t> &out) const {
+    if (!store_emitter)
+        OPENVINO_THROW("Store CPU emitter isn't initialized for jit_store_memory_emitter!");
+
+    store_emitter->emit_code(in, out, convert_to_size_t(aux_vec_idxs), convert_to_size_t(aux_gpr_idxs));
+}
+
+void jit_store_memory_emitter::emit_data() const {
+    store_emitter->emit_data();
+}
+
+}   // namespace aarch64
+}   // namespace intel_cpu
+}   // namespace ov

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_memory_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_memory_emitters.hpp
@@ -1,0 +1,93 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "emitters/plugin/aarch64/jit_emitter.hpp"
+#include "emitters/plugin/aarch64/jit_load_store_emitters.hpp"
+
+namespace ov {
+namespace intel_cpu {
+namespace aarch64 {
+
+/// \brief MemoryEmitter is the base class for emitters with load/store functionality.
+/// *Note*: post increment is embedded into Load/Store operation which means that
+/// it's illigal to load/store to the same address multiple times
+/// Typical application can be if Load and BroadcastLoad are performed from the same pointer.
+/// If Load goes before BroadcastLoad topologicaly the resilt will be incorrect
+/// For scalar loads we can use different loops. Tiling indeed can be arbitrary and post increment should be somehow coded into ISA.
+/// Blocked parameter to tell if input is actually blocked. Broadcast means broadcast by W in other cases no need to substitute load.
+class MemoryEmitter : public jit_emitter  {
+public:
+    MemoryEmitter(dnnl::impl::cpu::aarch64::jit_generator* h,
+                  dnnl::impl::cpu::aarch64::cpu_isa_t isa,
+                  const ov::snippets::lowered::ExpressionPtr& expr);
+
+protected:
+    ov::element::Type src_prc;
+    ov::element::Type dst_prc;
+
+    size_t count = 0;
+    size_t byte_offset = 0;
+};
+
+class jit_load_memory_emitter : public MemoryEmitter {
+public:
+    jit_load_memory_emitter(dnnl::impl::cpu::aarch64::jit_generator* h,
+                dnnl::impl::cpu::aarch64::cpu_isa_t isa,
+                const ov::snippets::lowered::ExpressionPtr& expr);
+
+    size_t get_inputs_count() const override {return 0;}
+
+private:
+    void emit_impl(const std::vector<size_t>& in,
+                   const std::vector<size_t>& out) const override;
+
+    template <dnnl::impl::cpu::aarch64::cpu_isa_t isa>
+    void emit_isa(const std::vector<size_t> &in, const std::vector<size_t> &out) const;
+    void emit_data() const override;
+
+private:
+    std::unique_ptr<jit_load_emitter> load_emitter = nullptr;
+};
+
+class jit_load_broadcast_emitter : public MemoryEmitter {
+public:
+    jit_load_broadcast_emitter(dnnl::impl::cpu::aarch64::jit_generator* h,
+                         dnnl::impl::cpu::aarch64::cpu_isa_t isa,
+                         const ov::snippets::lowered::ExpressionPtr& expr);
+
+    size_t get_inputs_count() const override {return 0;}
+
+private:
+    void emit_impl(const std::vector<size_t>& in,
+                   const std::vector<size_t>& out) const override;
+
+    template <dnnl::impl::cpu::aarch64::cpu_isa_t isa>
+    void emit_isa(const std::vector<size_t> &in, const std::vector<size_t> &out) const;
+};
+
+class jit_store_memory_emitter : public MemoryEmitter  {
+public:
+    jit_store_memory_emitter(dnnl::impl::cpu::aarch64::jit_generator* h,
+                 dnnl::impl::cpu::aarch64::cpu_isa_t isa,
+                 const ov::snippets::lowered::ExpressionPtr& expr);
+
+    size_t get_inputs_count() const override {return 1;}
+
+private:
+    void emit_impl(const std::vector<size_t>& in,
+                   const std::vector<size_t>& out) const override;
+
+    template <dnnl::impl::cpu::aarch64::cpu_isa_t isa>
+    void emit_isa(const std::vector<size_t> &in, const std::vector<size_t> &out) const;
+    void emit_data() const override;
+
+private:
+    std::unique_ptr<jit_store_emitter> store_emitter = nullptr;
+};
+
+}   // namespace aarch64
+}   // namespace intel_cpu
+}   // namespace ov

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_snippets_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_snippets_emitters.cpp
@@ -1,0 +1,101 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "jit_snippets_emitters.hpp"
+#include "cpu/aarch64/jit_generator.hpp"
+#include "cpu/aarch64/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_adr.h"
+
+using namespace Xbyak_aarch64;
+
+namespace ov {
+namespace intel_cpu {
+namespace aarch64 {
+
+using jit_generator = dnnl::impl::cpu::aarch64::jit_generator;
+using cpu_isa_t = dnnl::impl::cpu::aarch64::cpu_isa_t;
+using ExpressionPtr = ov::snippets::lowered::ExpressionPtr;
+
+NopEmitter::NopEmitter(jit_generator* h, cpu_isa_t isa, const ExpressionPtr& expr) : aarch64::jit_emitter(h, isa) {
+    in_out_type_ = emitter_in_out_map::gpr_to_gpr;
+}
+
+BroadcastMoveEmitter::BroadcastMoveEmitter(jit_generator* h, cpu_isa_t isa, const ExpressionPtr& expr)
+    : jit_emitter(h, isa) {
+    const auto n = expr->get_node();
+    if (n->get_input_element_type(0) != n->get_output_element_type(0))
+        OPENVINO_THROW("BroadcastMoveEmitter supports only equal input and output types but gets: ",
+                       n->get_input_element_type(0),
+                       " and ",
+                       n->get_output_element_type(0));
+    if (n->get_input_element_type(0) != ov::element::f32)
+        OPENVINO_THROW("BroadcastMoveEmitter only supports FP32 precision.");
+
+    byte_size = n->get_input_element_type(0).size();
+}
+
+void BroadcastMoveEmitter::emit_impl(const std::vector<size_t>& in,
+          const std::vector<size_t>& out) const {
+    if (host_isa_ == dnnl::impl::cpu::aarch64::asimd) {
+        emit_isa<dnnl::impl::cpu::aarch64::asimd>(in, out);
+    } else {
+        OPENVINO_THROW("BroadcastMove emitter doesn't support ", host_isa_);
+    }
+}
+
+template <cpu_isa_t isa>
+void BroadcastMoveEmitter::emit_isa(const std::vector<size_t> &in, const std::vector<size_t> &out) const {
+    using TReg = typename dnnl::impl::cpu::aarch64::cpu_isa_traits<isa>::TReg;
+    TReg src = TReg(in[0]);
+    TReg dst = TReg(out[0]);
+
+    switch (byte_size) {
+        case 4:
+            h->dup(dst.s, src.s[0]);
+            break;
+        default:
+            OPENVINO_THROW("unsupported data size ", byte_size);
+    }
+}
+
+ScalarEmitter::ScalarEmitter(jit_generator* h, cpu_isa_t isa, const ExpressionPtr& expr) : jit_emitter(h, isa) {
+    const auto n = expr->get_node();
+    const auto& precision = n->get_output_element_type(0);
+    switch (precision) {
+        case element::i32: {
+            value = ov::as_type_ptr<ov::op::v0::Constant>(n)->cast_vector<int32_t>()[0];
+            break;
+        }
+        case element::f32: {
+            value = dnnl::impl::float2int(ov::as_type_ptr<ov::op::v0::Constant>(n)->cast_vector<float>()[0]);
+            break;
+        }
+        default: {
+            OPENVINO_THROW("Scalar emitter doesn't support ", precision);
+        }
+    }
+    push_arg_entry_of("scalar", value, true);
+    prepare_table();
+}
+
+void ScalarEmitter::emit_impl(const std::vector<size_t>& in,
+                              const std::vector<size_t>& out) const {
+    if (host_isa_ == dnnl::impl::cpu::aarch64::asimd) {
+        emit_isa<dnnl::impl::cpu::aarch64::asimd>(in, out);
+    } else {
+        OPENVINO_THROW("Scalar emitter doesn't support ", host_isa_);
+    }
+}
+
+template <cpu_isa_t isa>
+void ScalarEmitter::emit_isa(const std::vector<size_t> &in, const std::vector<size_t> &out) const {
+    using TReg = typename dnnl::impl::cpu::aarch64::cpu_isa_traits<isa>::TReg;
+    TReg dst = TReg(out[0]);
+    AdrImm src = table_val("scalar");
+
+    h->uni_ld1rw(dst.s, src.getXn(), src.getImm());
+}
+
+}   // namespace aarch64
+}   // namespace intel_cpu
+}   // namespace ov

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_snippets_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_snippets_emitters.hpp
@@ -1,0 +1,69 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "emitters/plugin/aarch64/jit_emitter.hpp"
+
+namespace ov {
+namespace intel_cpu {
+namespace aarch64 {
+
+class NopEmitter : public jit_emitter {
+public:
+    NopEmitter(dnnl::impl::cpu::aarch64::jit_generator* h,
+               dnnl::impl::cpu::aarch64::cpu_isa_t isa,
+               const ov::snippets::lowered::ExpressionPtr& expr);
+
+    size_t get_inputs_count() const override {return 0;}
+
+private:
+    void emit_impl(const std::vector<size_t>& in,
+                   const std::vector<size_t>& out) const override {}
+};
+
+class BroadcastMoveEmitter : public jit_emitter {
+public:
+    BroadcastMoveEmitter(dnnl::impl::cpu::aarch64::jit_generator* h,
+                         dnnl::impl::cpu::aarch64::cpu_isa_t isa,
+                         const ov::snippets::lowered::ExpressionPtr& expr);
+
+    size_t get_inputs_count() const override {return 1;}
+
+private:
+    void emit_impl(const std::vector<size_t>& in,
+              const std::vector<size_t>& out) const override;
+
+    template <dnnl::impl::cpu::aarch64::cpu_isa_t isa>
+    void emit_isa(const std::vector<size_t> &in, const std::vector<size_t> &out) const;
+
+private:
+    size_t byte_size = 0lu;
+};
+
+class ScalarEmitter : public jit_emitter {
+public:
+    ScalarEmitter(dnnl::impl::cpu::aarch64::jit_generator* h,
+                  dnnl::impl::cpu::aarch64::cpu_isa_t isa,
+                  const ov::snippets::lowered::ExpressionPtr& expr);
+
+    size_t get_inputs_count() const override {return 0;}
+
+protected:
+    size_t get_aux_gprs_count() const override {return 1;}
+
+private:
+    void emit_impl(const std::vector<size_t>& in,
+              const std::vector<size_t>& out) const override;
+
+    template <dnnl::impl::cpu::aarch64::cpu_isa_t isa>
+    void emit_isa(const std::vector<size_t> &in, const std::vector<size_t> &out) const;
+
+private:
+    int32_t value;
+};
+
+}   // namespace aarch64
+}   // namespace intel_cpu
+}   // namespace ov

--- a/src/plugins/intel_cpu/src/nodes/subgraph.cpp
+++ b/src/plugins/intel_cpu/src/nodes/subgraph.cpp
@@ -5,7 +5,6 @@
 
 #include "common/primitive_hashing_utils.hpp"
 #include "dnnl_extension_utils.h"
-#include "emitters/snippets/x64/cpu_generator.hpp"
 #include "onednn/dnnl.h"
 #include "openvino/core/parallel.hpp"
 #include "openvino/core/rt_info.hpp"
@@ -21,6 +20,9 @@
 #include "snippets/lowered/pass/mark_loops.hpp"
 #include "transformations/defs.hpp"
 #include "transformations/cpu_opset/common/pass/convert_to_swish_cpu.hpp"
+
+#if defined(OPENVINO_ARCH_X86_64)
+#include "emitters/snippets/x64/cpu_generator.hpp"
 #include "transformations/snippets/x64/pass/lowered/brgemm_blocking.hpp"
 #include "transformations/snippets/x64/pass/lowered/fuse_load_store_and_convert.hpp"
 #include "transformations/snippets/x64/pass/lowered/set_brgemm_copy_b_buffers_shape.hpp"
@@ -30,6 +32,11 @@
 #include "transformations/snippets/x64/pass/brgemm_to_brgemm_cpu.hpp"
 #include "transformations/snippets/x64/pass/enforce_precision.hpp"
 #include "transformations/snippets/x64/shape_inference.hpp"
+#elif defined(OPENVINO_ARCH_ARM64)
+#include "emitters/snippets/aarch64/cpu_generator.hpp"
+#include "transformations/snippets/aarch64/shape_inference.hpp"
+#endif
+
 #include "utils/cpu_utils.hpp"
 #include "utils/ngraph_utils.hpp"
 
@@ -45,8 +52,14 @@ std::mutex err_print_lock;
 
 using namespace dnnl::impl::utils;
 using namespace dnnl::impl::cpu;
+
+#if defined(OPENVINO_ARCH_X86_64)
 using namespace dnnl::impl::cpu::x64;
 using namespace Xbyak;
+#elif defined(OPENVINO_ARCH_ARM64)
+using namespace dnnl::impl::cpu::aarch64;
+using namespace Xbyak_aarch64;
+#endif
 
 namespace ov {
 namespace intel_cpu {
@@ -127,8 +140,12 @@ bool SnippetKey::operator==(const SnippetKey& rhs) const {
 
 Snippet::Snippet(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& context)
         : Node(op, context, SnippetShapeInferFactory(op)) {
+#if defined(OPENVINO_ARCH_X86_64)
     host_isa = dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core) ?
         dnnl::impl::cpu::x64::avx512_core : dnnl::impl::cpu::x64::avx2;
+#elif defined(OPENVINO_ARCH_ARM64)
+    host_isa = dnnl::impl::cpu::aarch64::asimd;
+#endif
     const auto& tmp_snippet = ov::as_type_ptr<snippets::op::Subgraph>(op);
     OPENVINO_ASSERT(tmp_snippet, "Attempt to create Snippet node from an invalid op type");
     snippetAttrs.snippet = tmp_snippet->clone();
@@ -136,6 +153,8 @@ Snippet::Snippet(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& 
 
 #if defined(OPENVINO_ARCH_X86_64)
     snippetAttrs.snippet->set_generator(std::make_shared<CPUGenerator>(host_isa));
+#elif defined(OPENVINO_ARCH_ARM64)
+    snippetAttrs.snippet->set_generator(std::make_shared<aarch64::CPUGenerator>(host_isa));
 #else
     OPENVINO_THROW("CPU plugin: Snippets code-generator is not supported on non-x64 platforms");
 
@@ -206,7 +225,11 @@ void Snippet::initSupportedPrimitiveDescriptors() {
 
                 return std::make_shared<CpuBlockedMemoryDesc>(prc, shape, blocks, order, offset);
             } else if (lt == Blocked && shape.getRank() != 1 && (shape.getMinDims()[1] != Shape::UNDEFINED_DIM && shape.getMinDims()[1] > 1)) {
+#if defined(OPENVINO_ARCH_X86_64)
                 size_t blockSize = mayiuse(dnnl::impl::cpu::x64::avx512_core) ? 16 : 8;
+#elif defined(OPENVINO_ARCH_ARM64)
+                size_t blockSize = 16;
+#endif
 
                 VectorDims blocks = dims;
                 VectorDims order(blocks.size());
@@ -270,11 +293,15 @@ void Snippet::initSupportedPrimitiveDescriptors() {
         }
 
         impl_desc_type impl_type = impl_desc_type::unknown;
+#if defined(OPENVINO_ARCH_X86_64)
         if (mayiuse(x64::avx512_core)) {
             impl_type = impl_desc_type::jit_avx512;
         } else if (mayiuse(x64::avx2)) {
             impl_type = impl_desc_type::jit_avx2;
         }
+#elif defined(OPENVINO_ARCH_ARM64)
+        impl_type = impl_desc_type::jit_asimd;
+#endif
         return {config, impl_type};
     };
 

--- a/src/plugins/intel_cpu/src/nodes/subgraph.h
+++ b/src/plugins/intel_cpu/src/nodes/subgraph.h
@@ -4,10 +4,16 @@
 
 #pragma once
 
-#include "emitters/snippets/x64/jit_kernel_emitter.hpp"
 #include "node.h"
 #include "onednn/dnnl.h"
+#include "openvino/pass/visualize_tree.hpp"
 #include "snippets/op/subgraph.hpp"
+
+#if defined(OPENVINO_ARCH_X86_64)
+#include "emitters/snippets/x64/jit_kernel_emitter.hpp"
+#elif defined(OPENVINO_ARCH_ARM64)
+#include "emitters/snippets/aarch64/jit_kernel_emitter.hpp"
+#endif
 
 #include <array>
 
@@ -63,7 +69,11 @@ private:
     size_t outputNum = 0;
 
     // Holds ISA version used is codeGeneration target
+#if defined(OPENVINO_ARCH_X86_64)
     dnnl::impl::cpu::x64::cpu_isa_t host_isa;
+#elif defined(OPENVINO_ARCH_ARM64)
+    dnnl::impl::cpu::aarch64::cpu_isa_t host_isa;
+#endif
 
     std::vector<MemoryPtr> srcMemPtrs = {};
     std::vector<MemoryPtr> dstMemPtrs = {};
@@ -93,6 +103,10 @@ private:
             bool schedule_created();
 
         private:
+#if defined(OPENVINO_ARCH_ARM64)
+            using jit_snippets_compile_args = aarch64::jit_snippets_compile_args;
+            using jit_snippets_call_args = aarch64::jit_snippets_call_args;
+#endif
             static const size_t rank6D {6};
 
             typedef void (*kernel)(const void *, const void *);

--- a/src/plugins/intel_cpu/src/nodes_factory.cpp
+++ b/src/plugins/intel_cpu/src/nodes_factory.cpp
@@ -197,13 +197,13 @@ Node::NodesFactory::NodesFactory() : Factory("NodesFactory") {
     INTEL_CPU_NODE(DFT, Type::DFT);
     INTEL_CPU_NODE(RDFT, Type::RDFT);
     INTEL_CPU_NODE(ExtractImagePatches, Type::ExtractImagePatches);
+    INTEL_CPU_NODE(Snippet, Type::Subgraph);
 #if defined(OPENVINO_ARCH_X86_64)
     INTEL_CPU_NODE(FakeQuantize, Type::FakeQuantize);
     INTEL_CPU_NODE(GridSample, Type::GridSample);
     INTEL_CPU_NODE(Interaction, Type::Interaction);
     INTEL_CPU_NODE(MHA, Type::MHA);
     INTEL_CPU_NODE(ScaledDotProductAttention, Type::ScaledDotProductAttention);
-    INTEL_CPU_NODE(Snippet, Type::Subgraph);
 #endif
 }
 

--- a/src/plugins/intel_cpu/src/transformations/snippets/aarch64/shape_inference.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/aarch64/shape_inference.cpp
@@ -1,0 +1,34 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "shape_inference.hpp"
+#include "snippets/shape_inference/shape_infer_instances.hpp"
+#include "transformations/cpu_opset/common/op/swish_cpu.hpp"
+
+namespace ov {
+namespace snippets {
+using ShapeInferPtr = IShapeInferSnippetsFactory::ShapeInferPtr;
+
+ShapeInferPtr CPUShapeInferSnippetsFactory::get_specific_op_shape_infer(const ov::DiscreteTypeInfo& key,
+                                                                        const std::shared_ptr<ov::Node>& op) const {
+    const auto& maker_iter = specific_ops_registry.find(key);
+    if (maker_iter != specific_ops_registry.end())
+        return maker_iter->second(op);
+    return {};
+}
+
+#define SHAPE_INFER_PREDEFINED(OP, InferType) \
+    { OP::get_type_info_static(), [](const std::shared_ptr<ov::Node>& n) { return std::make_shared<InferType>();} }
+#define SHAPE_INFER_OP_SPECIFIC(OP) \
+    { OP::get_type_info_static(), [](const std::shared_ptr<ov::Node>& n) { return std::make_shared<OP::ShapeInfer>(n);} }
+#define SHAPE_INFER_OP_SPECIFIC_EXTERNAL(OP, InferType) \
+    { OP::get_type_info_static(), [](const std::shared_ptr<ov::Node>& n) { return std::make_shared<InferType>(n);} }
+
+// todo: Add implementation
+const CPUShapeInferSnippetsFactory::TRegistry CPUShapeInferSnippetsFactory::specific_ops_registry {};
+#undef SHAPE_INFER_OP_SPECIFIC
+#undef SHAPE_INFER_PREDEFINED
+
+} // namespace snippets
+} // namespace ov

--- a/src/plugins/intel_cpu/src/transformations/snippets/aarch64/shape_inference.hpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/aarch64/shape_inference.hpp
@@ -1,0 +1,28 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <snippets/shape_inference/shape_inference.hpp>
+
+namespace ov {
+namespace snippets {
+
+/**
+ * \brief Shape infer factory that can create shape-infer instances for cpu-specific operations
+ */
+class CPUShapeInferSnippetsFactory : public IShapeInferSnippetsFactory{
+    /** \brief Factory makers registry which can be specialized for key and value. */
+    static const TRegistry specific_ops_registry;
+
+protected:
+    /**
+    * @brief get shape infer instances for operations from backend-specific opset
+    * @return register ShapeInferPtr
+    */
+    ShapeInferPtr get_specific_op_shape_infer(const ov::DiscreteTypeInfo& key, const std::shared_ptr<ov::Node>& op) const override;
+};
+
+} // namespace snippets
+} // namespace ov

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -134,7 +134,11 @@
 #include "nodes/rnn.h"
 #include "nodes/scaled_attn.h"
 #include "dnnl.hpp"
+#if defined(OPENVINO_ARCH_X86_64)
 #include "cpu/x64/cpu_isa_traits.hpp"
+#elif defined(OPENVINO_ARCH_ARM64)
+#include "cpu/aarch64/cpu_isa_traits.hpp"
+#endif
 
 namespace ov {
 namespace intel_cpu {
@@ -712,8 +716,16 @@ void Transformations::PostLpt() {
 }
 
 void Transformations::MainSnippets(void) {
-    if (snippetsMode == Config::SnippetsMode::Disable ||
-        !dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx2)) // snippets are implemented only for relevant platforms (avx2+ extensions)
+    auto isSnippetsSupported = [](const ov::element::Type &inferencePrecision){
+#if defined(OPENVINO_ARCH_X86_64)
+        return dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx2);
+#elif defined(OPENVINO_ARCH_ARM64)
+        return dnnl::impl::cpu::aarch64::mayiuse(dnnl::impl::cpu::aarch64::asimd) && inferencePrecision == ov::element::f32;
+#endif
+        return false;
+    };
+
+    if (snippetsMode == Config::SnippetsMode::Disable || !isSnippetsSupported(inferencePrecision))
         return;
 
     ov::snippets::pass::SnippetsTokenization::Config tokenization_config;
@@ -737,7 +749,7 @@ void Transformations::MainSnippets(void) {
     snippetsManager.set_per_pass_validation(false);
     if (snippetsMode != Config::SnippetsMode::IgnoreCallback)
         CPU_REGISTER_PASS_X64(snippetsManager, SnippetsMarkSkipped, inferencePrecision != ov::element::f32);
-    CPU_REGISTER_PASS_X64(snippetsManager, snippets::pass::SnippetsTokenization, tokenization_config);
+    CPU_REGISTER_PASS_COMMON(snippetsManager, snippets::pass::SnippetsTokenization, tokenization_config);
 
     // - MHA has BRGEMM that is supported only on AVX512 platforms
     // - CPU Plugin Subgraph supports only f32, bf16 (and quantized) BRGEMM

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -306,7 +306,14 @@ std::vector<std::string> disabledTestPatterns() {
     retVector.emplace_back(R"(MultipleLSTMCellTest/MultipleLSTMCellTest.CompareWithRefs.*)");
     // int8 / code-generation specific
     retVector.emplace_back(R"(smoke_LPT.*)");
-    retVector.emplace_back(R"(smoke_Snippets.*)");
+    retVector.emplace_back(R"(smoke_Snippets(?!_Eltwise).*)");
+    // ConvertSaturation is not implemented for non-x64 CPU yet:
+    retVector.emplace_back(R"(.*Behavior.*InferRequestSetBlobByType.*)");
+    retVector.emplace_back(R"(.*Behavior.*OVCompiledGraphImportExportTest.*(i|u)8.*)");
+    retVector.emplace_back(R"(.*CompileModelCacheTestBase.CompareWithRefImpl.*(i|u)8.*)");
+    retVector.emplace_back(R"(.*LoadNetworkCacheTestBase.CompareWithRefImpl.*(i|u)8.*)");
+    retVector.emplace_back(R"(.*DepthToSpaceTransformation.CompareWithRefImpl.*)");
+    retVector.emplace_back(R"(smoke_Preprocessing/PreprocessingYUV2GreyTest.convert_(?!single).*)");
 #endif
 
 #if defined(_WIN32)

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/eltwise_two_results.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/eltwise_two_results.cpp
@@ -10,6 +10,10 @@ namespace test {
 namespace snippets {
 namespace {
 
+// todo: Remove the architecture constraint after isa sve_128 being supported. Because for now ARM Snippets only support isa asimd,
+// but dnnl injector jit_uni_eltwise_injector_f32 requires isa being at least sve_128. So dnnl emitters used by these test cases
+// are not supported for ARM architecture now.
+#if defined(OPENVINO_ARCH_X86_64)
 INSTANTIATE_TEST_SUITE_P(smoke_Snippets_Eltwise_TwoResults, EltwiseTwoResults,
                         ::testing::Combine(
                              ::testing::Values(InputShape {{}, {{1, 64, 10, 10}}}),
@@ -27,6 +31,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_Eltwise_TwoResults_Dynamic, EltwiseTwoRe
                              ::testing::Values(2),
                              ::testing::Values(ov::test::utils::DEVICE_CPU)),
                          EltwiseTwoResults::getTestCaseName);
+#endif
 
 } // namespace
 } // namespace snippets

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/max_num_params_eltwise.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/max_num_params_eltwise.cpp
@@ -9,6 +9,9 @@ namespace ov {
 namespace test {
 namespace snippets {
 namespace {
+
+// todo: Remove the architecture constraint after jit_eltwise_emitters for ARM having supported jit_power_dynamic_emitter
+#if defined(OPENVINO_ARCH_X86_64)
 // Note that we need these shapes to cover all cases of code emission (none/one/multiple of scalar/vector tiles)
 std::vector<InputShape> input_shapes {{{}, {{1, 64, 10, 10}}},
                                       {{}, {{1, 1, 17, 37}}},
@@ -30,6 +33,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_Eltwise, MaxNumParamsEltwise,
                              ::testing::Values(1),
                              ::testing::Values(ov::test::utils::DEVICE_CPU)),
                          MaxNumParamsEltwise::getTestCaseName);
+#endif
 
 } // namespace
 } // namespace snippets

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/two_inputs_and_outputs.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/two_inputs_and_outputs.cpp
@@ -10,6 +10,10 @@ namespace test {
 namespace snippets {
 namespace {
 
+// todo: Remove the architecture constraint after isa sve_128 being supported. Because for now ARM Snippets only support isa asimd,
+// but dnnl injector jit_uni_eltwise_injector_f32 requires isa being at least sve_128. So dnnl emitters used by these test cases
+// are not supported for ARM architecture now.
+#if defined(OPENVINO_ARCH_X86_64)
 const std::vector<std::vector<InputShape>> input_shapes = {
         { {{}, {{5, 5, 256, 1}}}, {{}, {{5, 5, 256, 1}}} },
         { {{}, {{5, 5, 16, 35}}}, {{}, {{5, 5, 16, 35}}} },
@@ -53,6 +57,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_Eltwise, TwoInputsAndOutputsWithReversed
                              ::testing::Values(1),
                              ::testing::Values(ov::test::utils::DEVICE_CPU)),
                          TwoInputsAndOutputsWithReversedOutputs::getTestCaseName);
+#endif
 
 }  // namespace
 } // namespace snippets

--- a/src/tests/functional/plugin/shared/src/preprocessing/yuv_to_grey_tests.cpp
+++ b/src/tests/functional/plugin/shared/src/preprocessing/yuv_to_grey_tests.cpp
@@ -4,6 +4,7 @@
 
 #include "preprocessing/yuv_to_grey_tests.hpp"
 #include "shared_test_classes/base/utils/generate_inputs.hpp"
+#include "functional_test_utils/skip_tests_config.hpp"
 
 namespace ov {
 namespace preprocess {
@@ -25,6 +26,7 @@ void PreprocessingYUV2GreyTest::SetUp() {
 }
 
 void PreprocessingYUV2GreyTest::run() {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED();
     compile_model();
     infer();
     validate();


### PR DESCRIPTION
### Details:
 - ***Feature***

 - *POC scope of Snippets on ARM architecture supports simple elementwise (combinations of Add, Multiply and Relu ops) subgraphs for FP32 precision.*

 - ***Implementations***
 - *aarch64 CPU Generator and TargetMachine*
 - *aarch64 load/store emitters*
 - *aarch64 control-flow emitters (Kernel, LoopBegin, LoopEnd, BroadcastMove, Scalar, Fill)*


### Tickets:
 - *[126738](https://jira.devtools.intel.com/browse/CVS-126738)*
